### PR TITLE
Bump cynic to 3.10.0 to match sui repo

### DIFF
--- a/crates/sui-graphql-client-build/Cargo.toml
+++ b/crates/sui-graphql-client-build/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-cynic-codegen = "3.8.0"
+cynic-codegen = "3.10.0"
 

--- a/crates/sui-graphql-client-build/README.md
+++ b/crates/sui-graphql-client-build/README.md
@@ -23,7 +23,7 @@ fn main() {
 # Cargo.toml
 # ...
 [dependencies]
-cynic = "3.8.0"
+cynic = "3.10.0"
 sui-graphql-client = { git = "https://github.com/mystenlabs/sui-rust-sdk", package = "sui-graphql-client", branch = "master" }
 
 [build-dependencies]

--- a/crates/sui-graphql-client-build/src/lib.rs
+++ b/crates/sui-graphql-client-build/src/lib.rs
@@ -17,7 +17,7 @@
 /// // Cargo.toml
 /// ...
 /// [dependencies]
-/// cynic = "3.8.0"
+/// cynic = "3.10.0"
 /// ...
 /// [build-dependencies]
 /// sui_graphql_client_build = "VERSION_HERE"

--- a/crates/sui-graphql-client/Cargo.toml
+++ b/crates/sui-graphql-client/Cargo.toml
@@ -15,7 +15,7 @@ async-trait = "0.1.61"
 base64ct = { version = "1.6.0", features = ["alloc", "std"] }
 bcs = "0.1.4"
 chrono = "0.4.26"
-cynic = "3.7.3"
+cynic = "3.10.0"
 futures = "0.3.29"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 serde = { version = "1.0.144" }


### PR DESCRIPTION
Planning to integrate `sui-replay-v2` into main sui repo, so getting some dependencies fixed to be the same.
https://github.com/MystenLabs/sui/pull/21545