### PR TITLE
sui-crypto: add QoL derives to keys

### DIFF
--- a/crates/sui-crypto/src/ed25519.rs
+++ b/crates/sui-crypto/src/ed25519.rs
@@ -7,6 +7,7 @@ use sui_sdk_types::SignatureScheme;
 use sui_sdk_types::SimpleSignature;
 use sui_sdk_types::UserSignature;
 
+#[derive(Clone, Eq, PartialEq)]
 pub struct Ed25519PrivateKey(ed25519_dalek::SigningKey);
 
 impl std::fmt::Debug for Ed25519PrivateKey {
@@ -133,7 +134,7 @@ impl Signer<UserSignature> for Ed25519PrivateKey {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
 pub struct Ed25519VerifyingKey(ed25519_dalek::VerifyingKey);
 
 impl Ed25519VerifyingKey {

--- a/crates/sui-crypto/src/multisig.rs
+++ b/crates/sui-crypto/src/multisig.rs
@@ -6,7 +6,7 @@ use sui_sdk_types::MultisigMemberPublicKey;
 use sui_sdk_types::MultisigMemberSignature;
 use sui_sdk_types::UserSignature;
 
-#[derive(Default)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct MultisigVerifier {
     #[cfg(feature = "zklogin")]
     zklogin_verifier: Option<crate::zklogin::ZkloginVerifier>,
@@ -217,7 +217,7 @@ impl Iterator for BitmapIndices {
 }
 
 /// Verifier that will verify all UserSignature variants
-#[derive(Default)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UserSignatureVerifier {
     inner: MultisigVerifier,
 }
@@ -276,6 +276,7 @@ impl Verifier<UserSignature> for UserSignatureVerifier {
     }
 }
 
+#[derive(Debug, Clone, PartialEq)]
 pub struct MultisigAggregator {
     committee: MultisigCommittee,
     signatures: std::collections::BTreeMap<usize, MultisigMemberSignature>,

--- a/crates/sui-crypto/src/secp256k1.rs
+++ b/crates/sui-crypto/src/secp256k1.rs
@@ -10,6 +10,7 @@ use sui_sdk_types::SignatureScheme;
 use sui_sdk_types::SimpleSignature;
 use sui_sdk_types::UserSignature;
 
+#[derive(Clone)]
 pub struct Secp256k1PrivateKey(SigningKey);
 
 impl std::fmt::Debug for Secp256k1PrivateKey {
@@ -135,7 +136,7 @@ impl Signer<UserSignature> for Secp256k1PrivateKey {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Secp256k1VerifyingKey(VerifyingKey);
 
 impl Secp256k1VerifyingKey {

--- a/crates/sui-crypto/src/secp256r1.rs
+++ b/crates/sui-crypto/src/secp256r1.rs
@@ -10,6 +10,7 @@ use sui_sdk_types::SignatureScheme;
 use sui_sdk_types::SimpleSignature;
 use sui_sdk_types::UserSignature;
 
+#[derive(Clone)]
 pub struct Secp256r1PrivateKey(SigningKey);
 
 impl std::fmt::Debug for Secp256r1PrivateKey {
@@ -135,7 +136,7 @@ impl Signer<UserSignature> for Secp256r1PrivateKey {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Secp256r1VerifyingKey(VerifyingKey);
 
 impl Secp256r1VerifyingKey {

--- a/crates/sui-crypto/src/simple.rs
+++ b/crates/sui-crypto/src/simple.rs
@@ -83,10 +83,12 @@ mod keypair {
     use sui_sdk_types::SimpleSignature;
     use sui_sdk_types::UserSignature;
 
+    #[derive(Debug, Clone)]
     pub struct SimpleKeypair {
         inner: InnerKeypair,
     }
 
+    #[derive(Debug, Clone)]
     enum InnerKeypair {
         #[cfg(feature = "ed25519")]
         Ed25519(crate::ed25519::Ed25519PrivateKey),
@@ -270,10 +272,12 @@ mod keypair {
         }
     }
 
+    #[derive(Debug, Clone, Eq, PartialEq)]
     pub struct SimpleVerifiyingKey {
         inner: InnerVerifyingKey,
     }
 
+    #[derive(Debug, Clone, Eq, PartialEq)]
     enum InnerVerifyingKey {
         #[cfg(feature = "ed25519")]
         Ed25519(crate::ed25519::Ed25519VerifyingKey),

--- a/crates/sui-crypto/src/zklogin/mod.rs
+++ b/crates/sui-crypto/src/zklogin/mod.rs
@@ -15,6 +15,7 @@ mod verify;
 #[cfg(test)]
 mod tests;
 
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ZkloginVerifier {
     proof_verifying_key: verify::VerifyingKey,
     jwks: HashMap<JwkId, Jwk>,

--- a/crates/sui-crypto/src/zklogin/verify.rs
+++ b/crates/sui-crypto/src/zklogin/verify.rs
@@ -24,7 +24,7 @@ use sui_sdk_types::ZkLoginProof;
 
 use super::POSEIDON;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Default)]
 pub struct VerifyingKey {
     inner: PreparedVerifyingKey<ark_bn254::Bn254>,
 }


### PR DESCRIPTION
Added `Debug`, `Clone`, `PartialEq`, `Eq` and `Default` derives where could. Inner structs already do implement these so just propagated to wrappers.