### PR TITLE
sui-rpc: allow constructing Client from a configured tonic Endpoint

### DIFF
--- a/crates/sui-rpc/src/client/mod.rs
+++ b/crates/sui-rpc/src/client/mod.rs
@@ -56,6 +56,17 @@ impl Client {
     /// URL for the public-good, Sui Foundation provided archive for testnet.
     pub const TESTNET_ARCHIVE: &str = "https://archive.testnet.sui.io";
 
+    pub fn from_endpoint(endpoint: &tonic::transport::Endpoint) -> Self {
+        let uri = endpoint.uri().clone();
+        let channel = endpoint.connect_lazy();
+        Self {
+            uri,
+            channel,
+            headers: Default::default(),
+            max_decoding_message_size: None,
+        }
+    }
+
     #[allow(clippy::result_large_err)]
     pub fn new<T>(uri: T) -> Result<Self>
     where


### PR DESCRIPTION
## Summary

Add `Client::from_endpoint(&tonic::transport::Endpoint)` to `sui-rpc`.

`Client::new` currently hardcodes a small set of transport settings, which makes it difficult for callers to tune connection behavior for reliability-sensitive use cases. In particular, callers may need to configure:

- connect timeout
- per-request timeout
- TCP keepalive
- HTTP/2 keepalive behavior

This change adds a constructor that lets callers build and tune a `tonic::transport::Endpoint` themselves and then create a `sui_rpc::Client` from it.

## Motivation

For some failure modes, especially when a TCP connection turns into a black hole, the default `Client::new` settings are not sufficient. Exposing an endpoint-based constructor gives callers access to tonic’s transport configuration without changing the existing `Client::new` API.
