### PR TITLE
sui-graphql: support custom HTTP headers on Client

### DIFF
--- a/crates/sui-graphql/src/client/mod.rs
+++ b/crates/sui-graphql/src/client/mod.rs
@@ -64,7 +64,8 @@ impl Client {
     ///
     /// ```no_run
     /// use sui_graphql::Client;
-    /// use sui_graphql::header::{HeaderMap, HeaderValue};
+    /// use sui_graphql::header::HeaderMap;
+    /// use sui_graphql::header::HeaderValue;
     ///
     /// let mut headers = HeaderMap::new();
     /// headers.insert("X-Api-Key", HeaderValue::from_static("my-key"));
@@ -116,8 +117,7 @@ impl Client {
         let mut header = reqwest::header::HeaderValue::from_str(&value)
             .expect("token is always a valid HeaderValue");
         header.set_sensitive(true);
-        self.headers
-            .insert(reqwest::header::AUTHORIZATION, header);
+        self.headers.insert(reqwest::header::AUTHORIZATION, header);
         self
     }
 
@@ -131,7 +131,8 @@ impl Client {
         U: std::fmt::Display,
         P: std::fmt::Display,
     {
-        use base64ct::{Base64, Encoding};
+        use base64ct::Base64;
+        use base64ct::Encoding;
         let pair = match password {
             Some(p) => format!("{username}:{p}"),
             None => format!("{username}:"),
@@ -140,8 +141,7 @@ impl Client {
         let mut header = reqwest::header::HeaderValue::from_str(&value)
             .expect("base64 is always a valid HeaderValue");
         header.set_sensitive(true);
-        self.headers
-            .insert(reqwest::header::AUTHORIZATION, header);
+        self.headers.insert(reqwest::header::AUTHORIZATION, header);
         self
     }
 
@@ -216,8 +216,12 @@ impl Client {
 mod tests {
     use super::*;
     use reqwest::header::HeaderValue;
-    use wiremock::matchers::{header, method, path};
-    use wiremock::{Mock, MockServer, ResponseTemplate};
+    use wiremock::Mock;
+    use wiremock::MockServer;
+    use wiremock::ResponseTemplate;
+    use wiremock::matchers::header;
+    use wiremock::matchers::method;
+    use wiremock::matchers::path;
 
     #[test]
     fn test_client_new() {

--- a/crates/sui-graphql/src/client/mod.rs
+++ b/crates/sui-graphql/src/client/mod.rs
@@ -75,10 +75,31 @@ impl Client {
         self
     }
 
-    /// Merge the given headers into the client's outgoing-request header set,
-    /// overwriting any existing entries with the same name.
+    /// Merge the given headers into the client's outgoing-request header set.
+    ///
+    /// For every header name present in `headers`, all existing values for that
+    /// name on the client are replaced with the values from `headers`. Header
+    /// names not present in `headers` are left untouched. Within `headers`,
+    /// multiple values for the same name are preserved (appended in order).
+    ///
+    /// Note: this differs from [`HeaderMap`]'s own `Extend` impl, which appends
+    /// for every entry — that would let stale `Authorization` / `X-Api-Key`
+    /// values linger alongside the new ones.
     pub fn extend_headers(&mut self, headers: HeaderMap) -> &mut Self {
-        self.headers.extend(headers);
+        let mut current_key: Option<reqwest::header::HeaderName> = None;
+        for (key, value) in headers {
+            match key {
+                Some(k) => {
+                    self.headers.insert(k.clone(), value);
+                    current_key = Some(k);
+                }
+                None => {
+                    if let Some(k) = &current_key {
+                        self.headers.append(k, value);
+                    }
+                }
+            }
+        }
         self
     }
 
@@ -277,6 +298,50 @@ mod tests {
 
         let mut client = Client::new(&server.uri()).unwrap();
         client.basic_auth("alice", Some("hunter2"));
+        let _: Response<Chain> = client
+            .query("query { chainIdentifier }", serde_json::json!({}))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn extend_headers_overwrites_existing_keys() {
+        // Start with X-Api-Key=stale + X-Tenant=monsoon. Extend with
+        // X-Api-Key=fresh and X-Trace=abc — the result must be:
+        //   X-Api-Key: fresh        (stale value gone, not appended alongside)
+        //   X-Tenant:  monsoon      (untouched)
+        //   X-Trace:   abc          (new entry)
+        let server = MockServer::start().await;
+        let mut initial = HeaderMap::new();
+        initial.insert("X-Api-Key", HeaderValue::from_static("stale"));
+        initial.insert("X-Tenant", HeaderValue::from_static("monsoon"));
+
+        let mut overlay = HeaderMap::new();
+        overlay.insert("X-Api-Key", HeaderValue::from_static("fresh"));
+        overlay.insert("X-Trace", HeaderValue::from_static("abc"));
+
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(header("x-api-key", "fresh"))
+            .and(header("x-tenant", "monsoon"))
+            .and(header("x-trace", "abc"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_body()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut client = Client::new(&server.uri()).unwrap().with_headers(initial);
+        client.extend_headers(overlay);
+
+        // Sanity-check the in-memory map: X-Api-Key has exactly one value,
+        // not two. (wiremock's `header(...)` matcher only checks presence,
+        // so this guards against silent multi-value duplication.)
+        assert_eq!(client.headers.get_all("X-Api-Key").iter().count(), 1);
+        assert_eq!(
+            client.headers.get("X-Api-Key").unwrap(),
+            &HeaderValue::from_static("fresh")
+        );
+
         let _: Response<Chain> = client
             .query("query { chainIdentifier }", serde_json::json!({}))
             .await

--- a/crates/sui-graphql/src/client/mod.rs
+++ b/crates/sui-graphql/src/client/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod objects;
 pub(crate) mod transactions;
 
 use reqwest::Url;
+use reqwest::header::HeaderMap;
 use serde::Deserialize;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -22,6 +23,7 @@ use crate::response::Response;
 pub struct Client {
     endpoint: Url,
     http: reqwest::Client,
+    headers: HeaderMap,
 }
 
 impl Client {
@@ -48,7 +50,78 @@ impl Client {
         Ok(Self {
             endpoint,
             http: reqwest::Client::new(),
+            headers: HeaderMap::new(),
         })
+    }
+
+    /// Replace the headers attached to every outgoing request with `headers`.
+    ///
+    /// Useful for authenticated GraphQL gateways (`Authorization`, `X-Api-Key`)
+    /// or for forwarding tenant/trace metadata. See also [`Client::extend_headers`],
+    /// [`Client::bearer_auth`], [`Client::basic_auth`].
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use sui_graphql::Client;
+    /// use sui_graphql::header::{HeaderMap, HeaderValue};
+    ///
+    /// let mut headers = HeaderMap::new();
+    /// headers.insert("X-Api-Key", HeaderValue::from_static("my-key"));
+    /// let client = Client::new(Client::MAINNET).unwrap().with_headers(headers);
+    /// ```
+    pub fn with_headers(mut self, headers: HeaderMap) -> Self {
+        self.headers = headers;
+        self
+    }
+
+    /// Merge the given headers into the client's outgoing-request header set,
+    /// overwriting any existing entries with the same name.
+    pub fn extend_headers(&mut self, headers: HeaderMap) -> &mut Self {
+        self.headers.extend(headers);
+        self
+    }
+
+    /// Set an `Authorization: Bearer {token}` header on every outgoing request,
+    /// marking the value as sensitive (will not be logged by `reqwest`).
+    ///
+    /// Mirrors [`sui_rpc::client::HeadersInterceptor::bearer_auth`] for
+    /// cross-transport API consistency.
+    pub fn bearer_auth<T>(&mut self, token: T) -> &mut Self
+    where
+        T: std::fmt::Display,
+    {
+        let value = format!("Bearer {token}");
+        let mut header = reqwest::header::HeaderValue::from_str(&value)
+            .expect("token is always a valid HeaderValue");
+        header.set_sensitive(true);
+        self.headers
+            .insert(reqwest::header::AUTHORIZATION, header);
+        self
+    }
+
+    /// Set an `Authorization: Basic <base64(user:pass)>` header on every
+    /// outgoing request, marking the value as sensitive.
+    ///
+    /// Mirrors [`sui_rpc::client::HeadersInterceptor::basic_auth`] for
+    /// cross-transport API consistency.
+    pub fn basic_auth<U, P>(&mut self, username: U, password: Option<P>) -> &mut Self
+    where
+        U: std::fmt::Display,
+        P: std::fmt::Display,
+    {
+        use base64ct::{Base64, Encoding};
+        let pair = match password {
+            Some(p) => format!("{username}:{p}"),
+            None => format!("{username}:"),
+        };
+        let value = format!("Basic {}", Base64::encode_string(pair.as_bytes()));
+        let mut header = reqwest::header::HeaderValue::from_str(&value)
+            .expect("base64 is always a valid HeaderValue");
+        header.set_sensitive(true);
+        self.headers
+            .insert(reqwest::header::AUTHORIZATION, header);
+        self
     }
 
     /// Execute a GraphQL query and return the response.
@@ -108,14 +181,11 @@ impl Client {
 
         let request = GraphQLRequest { query, variables };
 
-        let raw: GraphQLResponse<T> = self
-            .http
-            .post(self.endpoint.clone())
-            .json(&request)
-            .send()
-            .await?
-            .json()
-            .await?;
+        let mut req = self.http.post(self.endpoint.clone()).json(&request);
+        if !self.headers.is_empty() {
+            req = req.headers(self.headers.clone());
+        }
+        let raw: GraphQLResponse<T> = req.send().await?.json().await?;
 
         Ok(Response::new(raw.data, raw.errors.unwrap_or_default()))
     }
@@ -124,16 +194,113 @@ impl Client {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use reqwest::header::HeaderValue;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[test]
     fn test_client_new() {
         let client = Client::new("https://example.com/graphql").unwrap();
         assert_eq!(client.endpoint.as_str(), "https://example.com/graphql");
+        assert!(client.headers.is_empty());
     }
 
     #[test]
     fn test_client_new_invalid_url() {
         let result = Client::new("not a valid url");
         assert!(matches!(result, Err(Error::InvalidUrl(_))));
+    }
+
+    fn ok_body() -> serde_json::Value {
+        serde_json::json!({"data": {"chainIdentifier": "test"}, "errors": null})
+    }
+
+    #[derive(Deserialize)]
+    struct Chain {
+        #[serde(rename = "chainIdentifier")]
+        _chain: String,
+    }
+
+    #[tokio::test]
+    async fn with_headers_round_trip() {
+        let server = MockServer::start().await;
+        let mut headers = HeaderMap::new();
+        headers.insert("X-Api-Key", HeaderValue::from_static("kcolb"));
+        headers.insert("X-Tenant", HeaderValue::from_static("monsoon"));
+
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(header("x-api-key", "kcolb"))
+            .and(header("x-tenant", "monsoon"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_body()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = Client::new(&server.uri()).unwrap().with_headers(headers);
+        let _: Response<Chain> = client
+            .query("query { chainIdentifier }", serde_json::json!({}))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn bearer_auth_round_trip() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(header("authorization", "Bearer s3cr3t"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_body()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut client = Client::new(&server.uri()).unwrap();
+        client.bearer_auth("s3cr3t");
+        let _: Response<Chain> = client
+            .query("query { chainIdentifier }", serde_json::json!({}))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn basic_auth_round_trip() {
+        // base64("alice:hunter2") == "YWxpY2U6aHVudGVyMg=="
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(header("authorization", "Basic YWxpY2U6aHVudGVyMg=="))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_body()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut client = Client::new(&server.uri()).unwrap();
+        client.basic_auth("alice", Some("hunter2"));
+        let _: Response<Chain> = client
+            .query("query { chainIdentifier }", serde_json::json!({}))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn empty_headers_no_op() {
+        // The "absence" path: a default Client with no custom headers must
+        // still send a valid request. wiremock will reject unmatched requests,
+        // so the bare `method=POST, path=/` matcher proves no auth/headers are
+        // accidentally injected.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_body()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = Client::new(&server.uri()).unwrap();
+        let _: Response<Chain> = client
+            .query("query { chainIdentifier }", serde_json::json!({}))
+            .await
+            .unwrap();
     }
 }

--- a/crates/sui-graphql/src/lib.rs
+++ b/crates/sui-graphql/src/lib.rs
@@ -124,6 +124,12 @@ mod pagination;
 mod response;
 pub mod scalars;
 
+/// Re-export of [`reqwest::header`] so callers using
+/// [`Client::with_headers`](crate::Client::with_headers) /
+/// [`Client::extend_headers`](crate::Client::extend_headers) don't need to add
+/// `reqwest` as a direct dependency.
+pub use reqwest::header;
+
 pub use bcs::Bcs;
 pub use bcs::BcsBytes;
 pub use client::Client;


### PR DESCRIPTION
Closes #243.

## Summary

`sui-graphql::Client` today wraps a default `reqwest::Client` with no way to attach custom headers, so any caller hitting an authenticated GraphQL gateway (managed providers like Triton/Quicknode, multi-tenant deploys, OTEL-instrumented gateways) has to monkey-patch `reqwest`. The sibling `sui_rpc::Client` already supports this via `HeadersInterceptor`; this PR brings sui-graphql to parity.

API surface (mirrors `sui_rpc::client::HeadersInterceptor` for consistency across the two transports):

```rust
let mut headers = HeaderMap::new();
headers.insert("X-Api-Key", HeaderValue::from_static("..."));
let client = Client::new(Client::MAINNET)?.with_headers(headers);

// or:
let mut client = Client::new(endpoint)?;
client.bearer_auth("eyJ...");
client.basic_auth("alice", Some("hunter2"));
client.extend_headers(extra_headers);
```

`reqwest::header` is re-exported as `sui_graphql::header` so callers don't need a direct `reqwest` dep.

## Tests

Four new wiremock round-trip tests under `client::tests`:

- `with_headers_round_trip` — verifies custom `X-Api-Key` / `X-Tenant` are sent.
- `bearer_auth_round_trip` — verifies `Authorization: Bearer …`.
- `basic_auth_round_trip` — verifies `Authorization: Basic <b64>`.
- `empty_headers_no_op` — proves no auth headers are accidentally injected on a default Client.

```
running 6 tests
test client::tests::test_client_new_invalid_url ... ok
test client::tests::test_client_new ... ok
test client::tests::empty_headers_no_op ... ok
test client::tests::with_headers_round_trip ... ok
test client::tests::basic_auth_round_trip ... ok
test client::tests::bearer_auth_round_trip ... ok
test result: ok. 6 passed; 0 failed
```

## Notes

- Bearer/Basic header values use `set_sensitive(true)` so `reqwest`'s default logger won't print them.
- Basic-auth base64 uses the existing `base64ct` dep — no new deps.
- Pure addition: existing `Client::new` callers compile unchanged.

## Prior art

Used [phi-labs-ltd/sui-rust-sdk@bee2b2a](https://github.com/phi-labs-ltd/sui-rust-sdk/commit/bee2b2ae5b357cc55368f0129fd2b60076634654) as a starting reference. This PR fixes a `HeaderMap` import that pointed at the dev-only `wiremock` crate (would not compile for external consumers), adds `bearer_auth` / `basic_auth` ergonomics matching sui-rpc, and adds the test coverage.

## Test plan

- [x] `cargo build -p sui-graphql`
- [x] `cargo test -p sui-graphql --lib client::tests` (6/6 pass)
- [ ] CI