### PR TITLE
sui-graphql-macros: add graphql_query! for compile-time query validation

### DIFF
--- a/crates/sui-graphql-macros/Cargo.toml
+++ b/crates/sui-graphql-macros/Cargo.toml
@@ -26,6 +26,7 @@ syn = { version = "2.0", features = ["full", "parsing", "extra-traits"] }
 darling = "0.20"
 graphql-parser = "0.4"
 edit-distance = "2.1"
+apollo-compiler = "1.31"
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/sui-graphql-macros/src/lib.rs
+++ b/crates/sui-graphql-macros/src/lib.rs
@@ -1,12 +1,15 @@
-//! Compile-time validated derive macro for deserializing Sui GraphQL responses.
+//! Compile-time validated macros for the Sui GraphQL API.
 //!
-//! GraphQL responses are deeply nested JSON. Rather than manually writing
-//! `serde_json::Value` traversal code (with `.get()`, `.as_array()`, null checks, etc.),
-//! the [`Response`] derive macro generates all of that from a declarative field path.
-//! Paths are validated against the Sui GraphQL schema at compile time, so typos and
-//! type mismatches are caught before your code ever runs.
+//! Two macros, both validated against the embedded Sui GraphQL schema:
 //!
-//! For a complete client that uses this macro, see
+//! - [`Response`] — derive macro for response types. Generates JSON
+//!   deserialization from declarative field paths, catching unknown fields
+//!   and type mismatches before your code runs.
+//! - [`graphql_query!`] — function-style macro for query/mutation strings.
+//!   Validates the source against the schema, so unknown fields, undefined
+//!   variables, and bad arguments fail to compile.
+//!
+//! For a complete client that uses both, see
 //! [`sui-graphql`](https://docs.rs/sui-graphql).
 //!
 //! # Quick Start
@@ -140,6 +143,7 @@
 extern crate proc_macro;
 
 mod path;
+mod query;
 mod schema;
 mod validation;
 
@@ -244,6 +248,18 @@ pub fn derive_query_response(input: TokenStream) -> TokenStream {
         Ok(tokens) => tokens.into(),
         Err(err) => err.to_compile_error().into(),
     }
+}
+
+/// Validate a GraphQL query or mutation against the embedded Sui schema at
+/// compile time and return it as a `&'static str`.
+///
+/// On a syntactically or semantically invalid input (unknown field, wrong
+/// argument type, undefined variable, etc.) the macro emits one
+/// `compile_error!` per apollo-compiler diagnostic, so the offending call
+/// site fails to build with the diagnostic text inline.
+#[proc_macro]
+pub fn graphql_query(input: TokenStream) -> TokenStream {
+    query::expand(input)
 }
 
 fn derive_query_response_impl(input: DeriveInput) -> Result<TokenStream2, syn::Error> {

--- a/crates/sui-graphql-macros/src/query.rs
+++ b/crates/sui-graphql-macros/src/query.rs
@@ -1,0 +1,103 @@
+//! The `graphql_query!` function-style macro: compile-time validation and
+//! canonical formatting of GraphQL queries and mutations against the embedded
+//! Sui schema.
+//!
+//! Validation is delegated to `apollo-compiler`, which performs full GraphQL
+//! spec validation (selection set against schema, argument types, fragment
+//! shapes, variable usage, etc.). On success, the macro emits a `&'static str`
+//! literal containing the canonically formatted query. On failure, every
+//! diagnostic becomes a `syn::Error` anchored at the input literal's span.
+//!
+//! The macro is intentionally decoupled from any consumer crate: it produces
+//! a plain string literal so callers can wrap it in their own type. The
+//! `sui-graphql` crate ships a `macro_rules!` wrapper that nests this macro
+//! inside a `ValidatedQuery` constructor, but this proc macro itself has no
+//! dependency on or knowledge of that type.
+
+use std::sync::LazyLock;
+
+use apollo_compiler::ExecutableDocument;
+use apollo_compiler::Schema;
+use apollo_compiler::validation::Valid;
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::LitStr;
+
+/// Diagnostic label for the embedded SDL. apollo-compiler embeds this string
+/// into its error messages (e.g. `error at <sui schema>:42:5`); it does not
+/// open any file. The actual SDL bytes come from [`crate::schema::SCHEMA_SDL`].
+const SCHEMA_DIAGNOSTIC_LABEL: &str = "<sui schema>";
+
+/// Diagnostic label for the user's query string passed to `graphql!`. Same
+/// idea as [`SCHEMA_DIAGNOSTIC_LABEL`]: a string that appears in apollo's
+/// error messages, not a file path.
+const QUERY_DIAGNOSTIC_LABEL: &str = "<graphql! input>";
+
+/// `SCHEMA_SDL` parsed and validated into a form that can type-check incoming
+/// queries.
+///
+/// Cached for the lifetime of a single `cargo build`: parsing the full SDL is
+/// non-trivial, and proc macros are loaded once per build, so we parse on
+/// first use and reuse the result for every later `graphql!` call.
+///
+/// `Valid<Schema>` is apollo-compiler's marker that the schema itself is
+/// internally consistent; `ExecutableDocument::parse_and_validate` requires
+/// that proof. The `Result<_, String>` shape is what `LazyLock` needs (the
+/// cell value must be `Sync` and shareable across reads); if SDL parsing ever
+/// fails the cached message is reported at every call site.
+static VALIDATED_SCHEMA: LazyLock<Result<Valid<Schema>, String>> = LazyLock::new(|| {
+    Schema::parse_and_validate(crate::schema::SCHEMA_SDL, SCHEMA_DIAGNOSTIC_LABEL)
+        .map_err(|e| format!("Failed to parse Sui GraphQL schema: {e}"))
+});
+
+pub fn expand(input: TokenStream) -> TokenStream {
+    match expand_impl(input) {
+        Ok(tokens) => tokens.into(),
+        Err(err) => {
+            // Block-wrap with a `&str` tail; `compile_error!{...}` doesn't
+            // parse on its own in expression position.
+            let compile_error = err.to_compile_error();
+            quote!({ #compile_error "" }).into()
+        }
+    }
+}
+
+fn expand_impl(input: TokenStream) -> Result<TokenStream2, syn::Error> {
+    let lit: LitStr = syn::parse(input)?;
+    let source = lit.value();
+
+    let schema = VALIDATED_SCHEMA
+        .as_ref()
+        .map_err(|e| syn::Error::new(proc_macro2::Span::call_site(), e.clone()))?;
+
+    match ExecutableDocument::parse_and_validate(schema, source.as_str(), QUERY_DIAGNOSTIC_LABEL) {
+        Ok(valid) => {
+            let formatted = valid.to_string();
+            Ok(quote!(#formatted))
+        }
+        Err(with_errors) => {
+            let mut combined: Option<syn::Error> = None;
+            for diag in with_errors.errors.iter() {
+                let msg = match diag.line_column_range() {
+                    Some(range) => format!(
+                        "GraphQL [line {}, col {}]: {}",
+                        range.start.line, range.start.column, diag.error
+                    ),
+                    None => format!("GraphQL: {}", diag.error),
+                };
+                let err = syn::Error::new(proc_macro2::Span::call_site(), msg);
+                match &mut combined {
+                    Some(existing) => existing.combine(err),
+                    None => combined = Some(err),
+                }
+            }
+            Err(combined.unwrap_or_else(|| {
+                syn::Error::new(
+                    proc_macro2::Span::call_site(),
+                    "GraphQL validation failed with no diagnostics",
+                )
+            }))
+        }
+    }
+}

--- a/crates/sui-graphql-macros/src/schema.rs
+++ b/crates/sui-graphql-macros/src/schema.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::sync::LazyLock;
 
 /// The embedded Sui GraphQL schema.
-const SCHEMA_SDL: &str = include_str!("../schema/sui.graphql");
+pub(crate) const SCHEMA_SDL: &str = include_str!("../schema/sui.graphql");
 
 /// Parsed and indexed schema, cached for reuse across macro invocations.
 static SCHEMA: LazyLock<Result<Schema, String>> =

--- a/crates/sui-graphql-macros/tests/compile/graphql_query_invalid_syntax.rs
+++ b/crates/sui-graphql-macros/tests/compile/graphql_query_invalid_syntax.rs
@@ -1,0 +1,9 @@
+//! trybuild compile-fail: a malformed GraphQL document is rejected.
+
+use sui_graphql_macros::graphql_query;
+
+const Q: &str = graphql_query!("query { chainIdentifier");
+
+fn main() {
+    let _ = Q;
+}

--- a/crates/sui-graphql-macros/tests/compile/graphql_query_invalid_syntax.stderr
+++ b/crates/sui-graphql-macros/tests/compile/graphql_query_invalid_syntax.stderr
@@ -1,0 +1,7 @@
+error: GraphQL [line 1, col 24]: syntax error: expected R_CURLY, got EOF
+ --> tests/compile/graphql_query_invalid_syntax.rs:5:17
+  |
+5 | const Q: &str = graphql_query!("query { chainIdentifier");
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the macro `graphql_query` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/sui-graphql-macros/tests/compile/graphql_query_multiple_errors.rs
+++ b/crates/sui-graphql-macros/tests/compile/graphql_query_multiple_errors.rs
@@ -1,0 +1,17 @@
+//! trybuild compile-fail: a mix of one valid field and two invalid ones
+//! should produce two separate rustc errors (one per apollo diagnostic), not
+//! a single combined message.
+
+use sui_graphql_macros::graphql_query;
+
+const Q: &str = graphql_query!(
+    "query {
+        chainIdentifier
+        foo
+        bar
+    }"
+);
+
+fn main() {
+    let _ = Q;
+}

--- a/crates/sui-graphql-macros/tests/compile/graphql_query_multiple_errors.stderr
+++ b/crates/sui-graphql-macros/tests/compile/graphql_query_multiple_errors.stderr
@@ -1,0 +1,29 @@
+error: GraphQL [line 3, col 9]: type `Query` does not have a field `foo`
+  --> tests/compile/graphql_query_multiple_errors.rs:7:17
+   |
+ 7 |   const Q: &str = graphql_query!(
+   |  _________________^
+ 8 | |     "query {
+ 9 | |         chainIdentifier
+10 | |         foo
+11 | |         bar
+12 | |     }"
+13 | | );
+   | |_^
+   |
+   = note: this error originates in the macro `graphql_query` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: GraphQL [line 4, col 9]: type `Query` does not have a field `bar`
+  --> tests/compile/graphql_query_multiple_errors.rs:7:17
+   |
+ 7 |   const Q: &str = graphql_query!(
+   |  _________________^
+ 8 | |     "query {
+ 9 | |         chainIdentifier
+10 | |         foo
+11 | |         bar
+12 | |     }"
+13 | | );
+   | |_^
+   |
+   = note: this error originates in the macro `graphql_query` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/sui-graphql-macros/tests/compile/graphql_query_mutation.rs
+++ b/crates/sui-graphql-macros/tests/compile/graphql_query_mutation.rs
@@ -1,0 +1,17 @@
+//! trybuild compile-pass: a mutation validates and formats just like a query.
+
+use sui_graphql_macros::graphql_query;
+
+const M: &str = graphql_query!(
+    "mutation($txDataBcs: Base64!, $signatures: [Base64!]!) {
+        executeTransaction(transactionDataBcs: $txDataBcs, signatures: $signatures) {
+            effects {
+                effectsBcs
+            }
+        }
+    }"
+);
+
+fn main() {
+    assert!(!M.is_empty());
+}

--- a/crates/sui-graphql-macros/tests/compile/graphql_query_simple.rs
+++ b/crates/sui-graphql-macros/tests/compile/graphql_query_simple.rs
@@ -1,0 +1,9 @@
+//! trybuild compile-pass: a minimal valid query against the embedded schema.
+
+use sui_graphql_macros::graphql_query;
+
+const Q: &str = graphql_query!("query { chainIdentifier }");
+
+fn main() {
+    assert!(!Q.is_empty());
+}

--- a/crates/sui-graphql-macros/tests/compile/graphql_query_undefined_variable.rs
+++ b/crates/sui-graphql-macros/tests/compile/graphql_query_undefined_variable.rs
@@ -1,0 +1,15 @@
+//! trybuild compile-fail: referencing an undeclared variable is rejected.
+
+use sui_graphql_macros::graphql_query;
+
+const Q: &str = graphql_query!(
+    "query {
+        object(address: $id) {
+            version
+        }
+    }"
+);
+
+fn main() {
+    let _ = Q;
+}

--- a/crates/sui-graphql-macros/tests/compile/graphql_query_undefined_variable.stderr
+++ b/crates/sui-graphql-macros/tests/compile/graphql_query_undefined_variable.stderr
@@ -1,0 +1,14 @@
+error: GraphQL [line 2, col 25]: variable `$id` is not defined
+  --> tests/compile/graphql_query_undefined_variable.rs:5:17
+   |
+ 5 |   const Q: &str = graphql_query!(
+   |  _________________^
+ 6 | |     "query {
+ 7 | |         object(address: $id) {
+ 8 | |             version
+ 9 | |         }
+10 | |     }"
+11 | | );
+   | |_^
+   |
+   = note: this error originates in the macro `graphql_query` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/sui-graphql-macros/tests/compile/graphql_query_unknown_field.rs
+++ b/crates/sui-graphql-macros/tests/compile/graphql_query_unknown_field.rs
@@ -1,0 +1,9 @@
+//! trybuild compile-fail: a typo in a field name is rejected against the schema.
+
+use sui_graphql_macros::graphql_query;
+
+const Q: &str = graphql_query!("query { chainIdentifierr }");
+
+fn main() {
+    let _ = Q;
+}

--- a/crates/sui-graphql-macros/tests/compile/graphql_query_unknown_field.stderr
+++ b/crates/sui-graphql-macros/tests/compile/graphql_query_unknown_field.stderr
@@ -1,0 +1,7 @@
+error: GraphQL [line 1, col 9]: type `Query` does not have a field `chainIdentifierr`
+ --> tests/compile/graphql_query_unknown_field.rs:5:17
+  |
+5 | const Q: &str = graphql_query!("query { chainIdentifierr }");
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the macro `graphql_query` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/sui-graphql-macros/tests/compile/graphql_query_variable_typo.rs
+++ b/crates/sui-graphql-macros/tests/compile/graphql_query_variable_typo.rs
@@ -1,0 +1,16 @@
+//! trybuild compile-fail: variable is declared but the reference has a typo
+//! (declared as `$id`, referenced as `$idd`).
+
+use sui_graphql_macros::graphql_query;
+
+const Q: &str = graphql_query!(
+    "query($id: SuiAddress!) {
+        object(address: $idd) {
+            version
+        }
+    }"
+);
+
+fn main() {
+    let _ = Q;
+}

--- a/crates/sui-graphql-macros/tests/compile/graphql_query_variable_typo.stderr
+++ b/crates/sui-graphql-macros/tests/compile/graphql_query_variable_typo.stderr
@@ -1,0 +1,29 @@
+error: GraphQL [line 1, col 7]: unused variable: `$id`
+  --> tests/compile/graphql_query_variable_typo.rs:6:17
+   |
+ 6 |   const Q: &str = graphql_query!(
+   |  _________________^
+ 7 | |     "query($id: SuiAddress!) {
+ 8 | |         object(address: $idd) {
+ 9 | |             version
+10 | |         }
+11 | |     }"
+12 | | );
+   | |_^
+   |
+   = note: this error originates in the macro `graphql_query` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: GraphQL [line 2, col 25]: variable `$idd` is not defined
+  --> tests/compile/graphql_query_variable_typo.rs:6:17
+   |
+ 6 |   const Q: &str = graphql_query!(
+   |  _________________^
+ 7 | |     "query($id: SuiAddress!) {
+ 8 | |         object(address: $idd) {
+ 9 | |             version
+10 | |         }
+11 | |     }"
+12 | | );
+   | |_^
+   |
+   = note: this error originates in the macro `graphql_query` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/sui-graphql-macros/tests/compile/graphql_query_with_variables.rs
+++ b/crates/sui-graphql-macros/tests/compile/graphql_query_with_variables.rs
@@ -1,0 +1,16 @@
+//! trybuild compile-pass: query with typed variables resolves against the schema.
+
+use sui_graphql_macros::graphql_query;
+
+const Q: &str = graphql_query!(
+    "query($id: SuiAddress!) {
+        object(address: $id) {
+            address
+            version
+        }
+    }"
+);
+
+fn main() {
+    assert!(!Q.is_empty());
+}

--- a/crates/sui-graphql-macros/tests/compile_tests.rs
+++ b/crates/sui-graphql-macros/tests/compile_tests.rs
@@ -53,4 +53,14 @@ fn compile_tests() {
     t.compile_fail("tests/compile/enum_default_member_not_found.rs");
     t.compile_fail("tests/compile/enum_default_member_suggestion.rs");
     t.compile_fail("tests/compile/enum_missing_root_type.rs");
+
+    // graphql_query! macro tests
+    t.pass("tests/compile/graphql_query_simple.rs");
+    t.pass("tests/compile/graphql_query_with_variables.rs");
+    t.pass("tests/compile/graphql_query_mutation.rs");
+    t.compile_fail("tests/compile/graphql_query_unknown_field.rs");
+    t.compile_fail("tests/compile/graphql_query_undefined_variable.rs");
+    t.compile_fail("tests/compile/graphql_query_variable_typo.rs");
+    t.compile_fail("tests/compile/graphql_query_invalid_syntax.rs");
+    t.compile_fail("tests/compile/graphql_query_multiple_errors.rs");
 }

--- a/crates/sui-graphql/src/client/chain.rs
+++ b/crates/sui-graphql/src/client/chain.rs
@@ -1,6 +1,7 @@
 //! Chain information convenience methods.
 
 use sui_graphql_macros::Response;
+use sui_graphql_macros::graphql_query;
 
 use super::Client;
 use crate::error::Error;
@@ -55,7 +56,7 @@ impl Client {
             chain_identifier: Option<Digest>,
         }
 
-        const QUERY: &str = "query { chainIdentifier }";
+        const QUERY: &str = graphql_query!("query { chainIdentifier }");
 
         let response = self.query::<Response>(QUERY, serde_json::json!({})).await?;
 
@@ -86,7 +87,7 @@ impl Client {
             protocol_version: Option<u64>,
         }
 
-        const QUERY: &str = "query { protocolConfigs { protocolVersion } }";
+        const QUERY: &str = graphql_query!("query { protocolConfigs { protocolVersion } }");
 
         let response = self.query::<Response>(QUERY, serde_json::json!({})).await?;
 
@@ -141,8 +142,8 @@ impl Client {
             last_checkpoint_seq: Option<Vec<u64>>,
         }
 
-        const QUERY: &str = r#"
-            query($epochId: UInt53) {
+        const QUERY: &str = graphql_query!(
+            "query($epochId: UInt53) {
                 epoch(epochId: $epochId) {
                     epochId
                     protocolConfigs {
@@ -163,8 +164,8 @@ impl Client {
                         }
                     }
                 }
-            }
-        "#;
+            }"
+        );
 
         let variables = serde_json::json!({
             "epochId": epoch_id,

--- a/crates/sui-graphql/src/client/checkpoints.rs
+++ b/crates/sui-graphql/src/client/checkpoints.rs
@@ -1,6 +1,7 @@
 //! Checkpoint-related convenience methods.
 
 use sui_graphql_macros::Response;
+use sui_graphql_macros::graphql_query;
 use sui_sdk_types::CheckpointContents;
 use sui_sdk_types::CheckpointSummary;
 
@@ -40,14 +41,14 @@ impl Client {
             content_bcs: Option<Bcs<CheckpointContents>>,
         }
 
-        const QUERY: &str = r#"
-            query($sequenceNumber: UInt53) {
+        const QUERY: &str = graphql_query!(
+            "query($sequenceNumber: UInt53) {
                 checkpoint(sequenceNumber: $sequenceNumber) {
                     summaryBcs
                     contentBcs
                 }
-            }
-        "#;
+            }"
+        );
         let variables = serde_json::json!({ "sequenceNumber": sequence_number });
 
         let response = self.query::<Response>(QUERY, variables).await?;

--- a/crates/sui-graphql/src/client/coins.rs
+++ b/crates/sui-graphql/src/client/coins.rs
@@ -2,6 +2,7 @@
 
 use futures::Stream;
 use sui_graphql_macros::Response;
+use sui_graphql_macros::graphql_query;
 use sui_sdk_types::Address;
 use sui_sdk_types::StructTag;
 
@@ -65,8 +66,8 @@ impl Client {
             total_balance: Option<BigInt>,
         }
 
-        const QUERY: &str = r#"
-            query($owner: SuiAddress!, $coinType: String!) {
+        const QUERY: &str = graphql_query!(
+            "query($owner: SuiAddress!, $coinType: String!) {
                 address(address: $owner) {
                     balance(coinType: $coinType) {
                         coinType {
@@ -75,8 +76,8 @@ impl Client {
                         totalBalance
                     }
                 }
-            }
-        "#;
+            }"
+        );
 
         let variables = serde_json::json!({
             "owner": owner,
@@ -145,8 +146,8 @@ impl Client {
             total_balances: Option<Vec<Option<BigInt>>>,
         }
 
-        const QUERY: &str = r#"
-            query($owner: SuiAddress!, $after: String) {
+        const QUERY: &str = graphql_query!(
+            "query($owner: SuiAddress!, $after: String) {
                 address(address: $owner) {
                     balances(after: $after) {
                         pageInfo {
@@ -161,8 +162,8 @@ impl Client {
                         }
                     }
                 }
-            }
-        "#;
+            }"
+        );
 
         let variables = serde_json::json!({
             "owner": owner,

--- a/crates/sui-graphql/src/client/dynamic_fields.rs
+++ b/crates/sui-graphql/src/client/dynamic_fields.rs
@@ -3,6 +3,7 @@
 use futures::Stream;
 use serde::Serialize;
 use sui_graphql_macros::Response;
+use sui_graphql_macros::graphql_query;
 use sui_sdk_types::Address;
 use sui_sdk_types::TypeTag;
 
@@ -190,8 +191,8 @@ impl Client {
             page_info: Option<PageInfo>,
         }
 
-        const QUERY: &str = r#"
-            fragment MoveValueFields on MoveValue {
+        const QUERY: &str = graphql_query!(
+            "fragment MoveValueFields on MoveValue {
                 type { repr }
                 json @include(if: $withJson)
                 bcs @include(if: $withBcs)
@@ -216,8 +217,8 @@ impl Client {
                         }
                     }
                 }
-            }
-        "#;
+            }"
+        );
 
         let with_json = formats.contains(&Format::Json);
         let with_bcs = formats.is_empty() || formats.contains(&Format::Bcs);
@@ -265,8 +266,8 @@ impl Client {
             field: Option<DynamicField>,
         }
 
-        const DYNAMIC_FIELD_QUERY: &str = r#"
-            fragment MoveValueFields on MoveValue {
+        const DYNAMIC_FIELD_QUERY: &str = graphql_query!(
+            "fragment MoveValueFields on MoveValue {
                 type { repr }
                 json @include(if: $withJson)
                 bcs @include(if: $withBcs)
@@ -283,11 +284,11 @@ impl Client {
                         }
                     }
                 }
-            }
-        "#;
+            }"
+        );
 
-        const DYNAMIC_OBJECT_FIELD_QUERY: &str = r#"
-            fragment MoveValueFields on MoveValue {
+        const DYNAMIC_OBJECT_FIELD_QUERY: &str = graphql_query!(
+            "fragment MoveValueFields on MoveValue {
                 type { repr }
                 json @include(if: $withJson)
                 bcs @include(if: $withBcs)
@@ -304,8 +305,8 @@ impl Client {
                         }
                     }
                 }
-            }
-        "#;
+            }"
+        );
 
         let with_json = formats.contains(&Format::Json);
         let with_bcs = formats.is_empty() || formats.contains(&Format::Bcs);

--- a/crates/sui-graphql/src/client/execution.rs
+++ b/crates/sui-graphql/src/client/execution.rs
@@ -3,6 +3,7 @@
 use base64ct::Base64;
 use base64ct::Encoding;
 use sui_graphql_macros::Response;
+use sui_graphql_macros::graphql_query;
 use sui_rpc::proto::sui::rpc::v2::BalanceChange;
 use sui_sdk_types::Transaction;
 use sui_sdk_types::TransactionEffects;
@@ -53,16 +54,16 @@ impl Client {
             balance_changes: Option<Vec<BalanceChange>>,
         }
 
-        const MUTATION: &str = r#"
-            mutation($txDataBcs: Base64!, $signatures: [Base64!]!) {
+        const MUTATION: &str = graphql_query!(
+            "mutation($txDataBcs: Base64!, $signatures: [Base64!]!) {
                 executeTransaction(transactionDataBcs: $txDataBcs, signatures: $signatures) {
                     effects {
                         effectsBcs
                         balanceChangesJson
                     }
                 }
-            }
-        "#;
+            }"
+        );
 
         let tx_bytes =
             bcs::to_bytes(transaction).map_err(|e| Error::Serialization(e.to_string()))?;

--- a/crates/sui-graphql/src/client/objects.rs
+++ b/crates/sui-graphql/src/client/objects.rs
@@ -2,6 +2,7 @@
 
 use futures::Stream;
 use sui_graphql_macros::Response;
+use sui_graphql_macros::graphql_query;
 use sui_sdk_types::Address;
 use sui_sdk_types::Object;
 
@@ -45,13 +46,13 @@ impl Client {
             object: Option<Bcs<Object>>,
         }
 
-        const QUERY: &str = r#"
-            query($id: SuiAddress!) {
+        const QUERY: &str = graphql_query!(
+            "query($id: SuiAddress!) {
                 object(address: $id) {
                     objectBcs
                 }
-            }
-        "#;
+            }"
+        );
 
         let variables = serde_json::json!({ "id": object_id });
 
@@ -72,13 +73,13 @@ impl Client {
             object: Option<Bcs<Object>>,
         }
 
-        const QUERY: &str = r#"
-            query($id: SuiAddress!, $version: UInt53) {
+        const QUERY: &str = graphql_query!(
+            "query($id: SuiAddress!, $version: UInt53) {
                 object(address: $id, version: $version) {
                     objectBcs
                 }
-            }
-        "#;
+            }"
+        );
 
         let variables = serde_json::json!({
             "id": object_id,
@@ -104,13 +105,13 @@ impl Client {
             object: Option<Bcs<Object>>,
         }
 
-        const QUERY: &str = r#"
-            query($id: SuiAddress!, $atCheckpoint: UInt53) {
+        const QUERY: &str = graphql_query!(
+            "query($id: SuiAddress!, $atCheckpoint: UInt53) {
                 object(address: $id, atCheckpoint: $atCheckpoint) {
                     objectBcs
                 }
-            }
-        "#;
+            }"
+        );
 
         let variables = serde_json::json!({
             "id": object_id,
@@ -138,13 +139,13 @@ impl Client {
             object: Option<Bcs<Object>>,
         }
 
-        const QUERY: &str = r#"
-            query($id: SuiAddress!, $rootVersion: UInt53) {
+        const QUERY: &str = graphql_query!(
+            "query($id: SuiAddress!, $rootVersion: UInt53) {
                 object(address: $id, rootVersion: $rootVersion) {
                     objectBcs
                 }
-            }
-        "#;
+            }"
+        );
 
         let variables = serde_json::json!({
             "id": object_id,
@@ -202,8 +203,8 @@ impl Client {
             objects: Option<Vec<Bcs<Object>>>,
         }
 
-        const QUERY: &str = r#"
-            query($owner: SuiAddress!, $after: String) {
+        const QUERY: &str = graphql_query!(
+            "query($owner: SuiAddress!, $after: String) {
                 objects(filter: { owner: $owner }, after: $after) {
                     pageInfo {
                         hasNextPage
@@ -213,8 +214,8 @@ impl Client {
                         objectBcs
                     }
                 }
-            }
-        "#;
+            }"
+        );
 
         let variables = serde_json::json!({
             "owner": owner,

--- a/crates/sui-graphql/src/client/transactions.rs
+++ b/crates/sui-graphql/src/client/transactions.rs
@@ -1,6 +1,7 @@
 //! Transaction-related convenience methods.
 
 use sui_graphql_macros::Response;
+use sui_graphql_macros::graphql_query;
 use sui_sdk_types::Transaction;
 use sui_sdk_types::TransactionEffects;
 
@@ -76,8 +77,8 @@ impl Client {
             timestamp: Option<DateTime>,
         }
 
-        const QUERY: &str = r#"
-            query($digest: String!) {
+        const QUERY: &str = graphql_query!(
+            "query($digest: String!) {
                 transaction(digest: $digest) {
                     transactionBcs
                     effects {
@@ -89,8 +90,8 @@ impl Client {
                         timestamp
                     }
                 }
-            }
-        "#;
+            }"
+        );
 
         let variables = serde_json::json!({ "digest": digest });
 

--- a/crates/sui-graphql/src/lib.rs
+++ b/crates/sui-graphql/src/lib.rs
@@ -55,15 +55,17 @@
 //!
 //! For queries beyond the built-in methods, use [`Client::query`] with a
 //! response type that implements [`serde::de::DeserializeOwned`]. The
-//! [`sui-graphql-macros`] crate provides `#[derive(Response)]` which generates
-//! the deserialization code from declarative field paths, with compile-time
-//! validation against the Sui GraphQL schema.
+//! [`sui-graphql-macros`] crate provides `graphql_query!` to validate the
+//! query string and `#[derive(Response)]` to generate the response
+//! deserialization code, both checked against the Sui GraphQL schema at
+//! compile time.
 //!
 //! [`sui-graphql-macros`]: https://docs.rs/sui-graphql-macros
 //!
 //! ```no_run
 //! use sui_graphql::Client;
 //! use sui_graphql_macros::Response;
+//! use sui_graphql_macros::graphql_query;
 //!
 //! // Define a response type with field paths into the GraphQL response JSON.
 //! // Paths are validated against the schema at compile time — typos like
@@ -85,18 +87,19 @@
 //! async fn main() -> Result<(), sui_graphql::Error> {
 //!     let client = Client::new(Client::MAINNET)?;
 //!
-//!     let query = r#"
-//!         query($epoch_id: UInt53) {
-//!             epoch(id: $epoch_id) {
+//!     // `graphql_query!` validates the query against the schema at compile time.
+//!     const QUERY: &str = graphql_query!(
+//!         "query($epochId: UInt53) {
+//!             epoch(epochId: $epochId) {
 //!                 epochId
 //!                 checkpoints { nodes { digest } }
 //!                 referenceGasPrice
 //!             }
-//!         }
-//!     "#;
-//!     let variables = serde_json::json!({ "epoch_id": 100 });
+//!         }"
+//!     );
+//!     let variables = serde_json::json!({ "epochId": 100 });
 //!
-//!     let response = client.query::<MyResponse>(query, variables).await?;
+//!     let response = client.query::<MyResponse>(QUERY, variables).await?;
 //!
 //!     // GraphQL supports partial success — data and errors can coexist
 //!     for err in response.errors() {
@@ -148,3 +151,4 @@ pub use pagination::PageInfo;
 pub use pagination::paginate;
 pub use pagination::paginate_backward;
 pub use response::Response;
+pub use sui_graphql_macros::graphql_query;


### PR DESCRIPTION
## Summary
- Adds `graphql_query!` proc macro in `sui-graphql-macros` that parses and validates GraphQL queries and mutations against the embedded Sui schema using `apollo-compiler`. Unknown fields, undefined variables, and bad arguments fail to compile.
- Migrates all 16 `const QUERY` / `const MUTATION` literals in `crates/sui-graphql/src/client/*.rs` to use the macro.

## Test plan
- `cargo test -p sui-graphql -p sui-graphql-macros`