### PR TITLE
sui-sdk-types: probe for trailing intent-message wrapper elements

### DIFF
--- a/crates/sui-sdk-types/src/transaction/serialization.rs
+++ b/crates/sui-sdk-types/src/transaction/serialization.rs
@@ -271,6 +271,17 @@ mod signed_transaction {
                         } = seq.next_element()?.ok_or_else(|| {
                             serde::de::Error::custom("expected a sequence with length 1")
                         })?;
+
+                        // Reject deserializers that don't expose `size_hint`
+                        // but provide more elements than expected — without
+                        // this probe, trailing elements would be silently
+                        // dropped.
+                        if seq.next_element::<serde::de::IgnoredAny>()?.is_some() {
+                            return Err(serde::de::Error::custom(
+                                "expected a sequence with length 1",
+                            ));
+                        }
+
                         Ok(SignedTransaction {
                             transaction,
                             signatures,


### PR DESCRIPTION
Previously, the `SignedTransactionWithIntentMessage` deserializer enforced the "exactly one element" invariant only when the underlying deserializer reported a known size via `size_hint`. For format-agnostic non-self-describing deserializers that omit `size_hint`, the check was skipped entirely and only the first element was consumed; any trailing elements were silently dropped. With this commit, after consuming the first element, probe `seq.next_element::<serde::de::IgnoredAny>()` and reject if it returns `Some`, matching the standard serde pattern for fixed-length sequences.

For BCS (the production format) the existing `size_hint` check still fires first, so existing tests cover the no-regression path. A dedicated test for the new probe would need a custom format that omits `size_hint` while supporting `deserialize_ignored_any` — neither BCS (no `size_hint`-less mode, no ignored-any support) nor JSON (always provides `size_hint` for arrays) qualify, so the new branch is covered only by code review.