### PR TITLE
sui-crypto: add support for the `suiprivkey` Bech32 key format

### DIFF
--- a/crates/sui-crypto/Cargo.toml
+++ b/crates/sui-crypto/Cargo.toml
@@ -53,6 +53,11 @@ pem = [
 ]
 bls12381 = ["dep:blst", "dep:rand_core", "signature/std"]
 
+# Loading and storing private keys in the `suiprivkey` Bech32 format produced
+# by the Sui CLI. Pulls in the `bech32` dependency. Useful only when at least
+# one of `ed25519`, `secp256k1`, or `secp256r1` is also enabled.
+bech32 = ["dep:bech32"]
+
 [dependencies]
 signature = "2.2"
 sui-sdk-types = { version = "0.3.0", path = "../sui-sdk-types", default-features = false, features = ["hash", "serde"] }
@@ -91,6 +96,9 @@ pem-rfc7468 = { version = "0.7", optional = true, features = ["std"] }
 
 # bls12381 support
 blst = { version = "0.3.13", optional = true }
+
+# suiprivkey (Bech32) support.
+bech32 = { version = "0.11", default-features = false, features = ["alloc"], optional = true }
 
 [dev-dependencies]
 bcs = { version = "0.1.6" }

--- a/crates/sui-crypto/src/ed25519.rs
+++ b/crates/sui-crypto/src/ed25519.rs
@@ -107,6 +107,34 @@ impl Ed25519PrivateKey {
     pub(crate) fn from_dalek(private_key: ed25519_dalek::SigningKey) -> Self {
         Self(private_key)
     }
+
+    #[cfg(feature = "bech32")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "bech32")))]
+    /// Decode a Bech32 `suiprivkey` string produced by the Sui CLI.
+    ///
+    /// Returns an error if the string does not have the `suiprivkey` HRP, has
+    /// an invalid Bech32 (BIP-173) checksum, has a flag byte that is not
+    /// Ed25519, or has the wrong number of key bytes.
+    pub fn from_suiprivkey(s: &str) -> Result<Self, SignatureError> {
+        let (scheme, key) = crate::suipriv::decode(s)?;
+        if scheme != SignatureScheme::Ed25519 {
+            return Err(SignatureError::from_source(format!(
+                "suipriv scheme flag is `{}`, expected `ed25519`",
+                scheme.name(),
+            )));
+        }
+        let bytes: [u8; Self::LENGTH] = key.try_into().map_err(|_: Vec<u8>| {
+            SignatureError::from_source("suipriv key has invalid length for ed25519")
+        })?;
+        Ok(Self::new(bytes))
+    }
+
+    #[cfg(feature = "bech32")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "bech32")))]
+    /// Encode this private key as a Bech32 `suiprivkey` string.
+    pub fn to_suiprivkey(&self) -> Result<String, SignatureError> {
+        crate::suipriv::encode(SignatureScheme::Ed25519, self.0.to_bytes().as_slice())
+    }
 }
 
 impl Signer<Ed25519Signature> for Ed25519PrivateKey {

--- a/crates/sui-crypto/src/lib.rs
+++ b/crates/sui-crypto/src/lib.rs
@@ -51,11 +51,7 @@ pub mod simple;
 
 #[cfg(all(
     feature = "bech32",
-    any(
-        feature = "ed25519",
-        feature = "secp256r1",
-        feature = "secp256k1"
-    )
+    any(feature = "ed25519", feature = "secp256r1", feature = "secp256k1")
 ))]
 mod suipriv;
 

--- a/crates/sui-crypto/src/lib.rs
+++ b/crates/sui-crypto/src/lib.rs
@@ -49,6 +49,16 @@ pub mod zklogin;
 )]
 pub mod simple;
 
+#[cfg(all(
+    feature = "bech32",
+    any(
+        feature = "ed25519",
+        feature = "secp256r1",
+        feature = "secp256k1"
+    )
+))]
+mod suipriv;
+
 #[cfg(any(
     feature = "ed25519",
     feature = "secp256r1",

--- a/crates/sui-crypto/src/secp256k1.rs
+++ b/crates/sui-crypto/src/secp256k1.rs
@@ -110,6 +110,36 @@ impl Secp256k1PrivateKey {
     pub(crate) fn from_k256(private_key: SigningKey) -> Self {
         Self(private_key)
     }
+
+    #[cfg(feature = "bech32")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "bech32")))]
+    /// Decode a Bech32 `suiprivkey` string produced by the Sui CLI.
+    ///
+    /// Returns an error if the string does not have the `suiprivkey` HRP, has
+    /// an invalid Bech32 (BIP-173) checksum, has a flag byte that is not
+    /// Secp256k1, has the wrong number of key bytes, or carries bytes that do
+    /// not form a valid secp256k1 scalar.
+    pub fn from_suiprivkey(s: &str) -> Result<Self, SignatureError> {
+        let (scheme, key) = crate::suipriv::decode(s)?;
+        if scheme != SignatureScheme::Secp256k1 {
+            return Err(SignatureError::from_source(format!(
+                "suipriv scheme flag is `{}`, expected `secp256k1`",
+                scheme.name(),
+            )));
+        }
+        let bytes: [u8; Self::LENGTH] = key.try_into().map_err(|_: Vec<u8>| {
+            SignatureError::from_source("suipriv key has invalid length for secp256k1")
+        })?;
+        Self::new(bytes)
+    }
+
+    #[cfg(feature = "bech32")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "bech32")))]
+    /// Encode this private key as a Bech32 `suiprivkey` string.
+    pub fn to_suiprivkey(&self) -> Result<String, SignatureError> {
+        let bytes = self.0.to_bytes();
+        crate::suipriv::encode(SignatureScheme::Secp256k1, &bytes)
+    }
 }
 
 impl Signer<Secp256k1Signature> for Secp256k1PrivateKey {

--- a/crates/sui-crypto/src/secp256r1.rs
+++ b/crates/sui-crypto/src/secp256r1.rs
@@ -110,6 +110,35 @@ impl Secp256r1PrivateKey {
     pub(crate) fn from_p256(private_key: SigningKey) -> Self {
         Self(private_key)
     }
+
+    #[cfg(feature = "bech32")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "bech32")))]
+    /// Decode a Bech32 `suiprivkey` string produced by the Sui CLI.
+    ///
+    /// Returns an error if the string does not have the `suiprivkey` HRP, has
+    /// an invalid Bech32 (BIP-173) checksum, has a flag byte that is not
+    /// Secp256r1, or has the wrong number of key bytes.
+    pub fn from_suiprivkey(s: &str) -> Result<Self, SignatureError> {
+        let (scheme, key) = crate::suipriv::decode(s)?;
+        if scheme != SignatureScheme::Secp256r1 {
+            return Err(SignatureError::from_source(format!(
+                "suipriv scheme flag is `{}`, expected `secp256r1`",
+                scheme.name(),
+            )));
+        }
+        let bytes: [u8; Self::LENGTH] = key.try_into().map_err(|_: Vec<u8>| {
+            SignatureError::from_source("suipriv key has invalid length for secp256r1")
+        })?;
+        Ok(Self::new(bytes))
+    }
+
+    #[cfg(feature = "bech32")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "bech32")))]
+    /// Encode this private key as a Bech32 `suiprivkey` string.
+    pub fn to_suiprivkey(&self) -> Result<String, SignatureError> {
+        let bytes = self.0.to_bytes();
+        crate::suipriv::encode(SignatureScheme::Secp256r1, &bytes)
+    }
 }
 
 impl Signer<Secp256r1Signature> for Secp256r1PrivateKey {

--- a/crates/sui-crypto/src/simple.rs
+++ b/crates/sui-crypto/src/simple.rs
@@ -715,6 +715,9 @@ mod test {
         use super::*;
         use sui_sdk_types::SignatureScheme;
 
+        #[cfg(target_arch = "wasm32")]
+        use wasm_bindgen_test::wasm_bindgen_test as test;
+
         // Upstream test vector: `Ed25519KeyPair::generate(&mut StdRng::from_seed([0; 32]))`
         // encoded with `SuiKeyPair::encode()` produces this string. The leading
         // flag byte is 0x00 (Ed25519); the remaining 32 bytes are the private

--- a/crates/sui-crypto/src/simple.rs
+++ b/crates/sui-crypto/src/simple.rs
@@ -220,6 +220,70 @@ mod keypair {
                 InnerKeypair::Secp256r1(private_key) => private_key.to_pem(),
             }
         }
+
+        #[cfg(feature = "bech32")]
+        #[cfg_attr(doc_cfg, doc(cfg(feature = "bech32")))]
+        /// Decode a Bech32 `suiprivkey` string produced by the Sui CLI.
+        ///
+        /// The leading flag byte selects the scheme. Only the simple schemes
+        /// (Ed25519, Secp256k1, Secp256r1) are accepted, matching the
+        /// upstream `sui-types` parser.
+        pub fn from_suiprivkey(s: &str) -> Result<Self, SignatureError> {
+            let (scheme, key) = crate::suipriv::decode(s)?;
+            let inner = match scheme {
+                #[cfg(feature = "ed25519")]
+                SignatureScheme::Ed25519 => {
+                    let bytes: [u8; crate::ed25519::Ed25519PrivateKey::LENGTH] =
+                        key.try_into().map_err(|_: Vec<u8>| {
+                            SignatureError::from_source(
+                                "suipriv key has invalid length for ed25519",
+                            )
+                        })?;
+                    InnerKeypair::Ed25519(crate::ed25519::Ed25519PrivateKey::new(bytes))
+                }
+                #[cfg(feature = "secp256k1")]
+                SignatureScheme::Secp256k1 => {
+                    let bytes: [u8; crate::secp256k1::Secp256k1PrivateKey::LENGTH] =
+                        key.try_into().map_err(|_: Vec<u8>| {
+                            SignatureError::from_source(
+                                "suipriv key has invalid length for secp256k1",
+                            )
+                        })?;
+                    InnerKeypair::Secp256k1(crate::secp256k1::Secp256k1PrivateKey::new(bytes)?)
+                }
+                #[cfg(feature = "secp256r1")]
+                SignatureScheme::Secp256r1 => {
+                    let bytes: [u8; crate::secp256r1::Secp256r1PrivateKey::LENGTH] =
+                        key.try_into().map_err(|_: Vec<u8>| {
+                            SignatureError::from_source(
+                                "suipriv key has invalid length for secp256r1",
+                            )
+                        })?;
+                    InnerKeypair::Secp256r1(crate::secp256r1::Secp256r1PrivateKey::new(bytes))
+                }
+                other => {
+                    return Err(SignatureError::from_source(format!(
+                        "unsupported scheme `{}` in suipriv encoding",
+                        other.name(),
+                    )));
+                }
+            };
+            Ok(Self { inner })
+        }
+
+        #[cfg(feature = "bech32")]
+        #[cfg_attr(doc_cfg, doc(cfg(feature = "bech32")))]
+        /// Encode this private key as a Bech32 `suiprivkey` string.
+        pub fn to_suiprivkey(&self) -> Result<String, SignatureError> {
+            match &self.inner {
+                #[cfg(feature = "ed25519")]
+                InnerKeypair::Ed25519(private_key) => private_key.to_suiprivkey(),
+                #[cfg(feature = "secp256k1")]
+                InnerKeypair::Secp256k1(private_key) => private_key.to_suiprivkey(),
+                #[cfg(feature = "secp256r1")]
+                InnerKeypair::Secp256r1(private_key) => private_key.to_suiprivkey(),
+            }
+        }
     }
 
     impl Signer<SimpleSignature> for SimpleKeypair {
@@ -637,5 +701,111 @@ mod test {
         assert_eq!(der, from_der.to_der().unwrap());
         let from_pem = SimpleVerifiyingKey::from_pem(&pem).unwrap();
         assert_eq!(pem, from_pem.to_pem().unwrap());
+    }
+
+    // Round-trip and rejection tests for the suiprivkey Bech32 format.
+    //
+    // These mirror the format produced by the Sui CLI and the upstream
+    // `sui-types` crate. `EXPECTED_ED25519_VECTOR` is taken directly from
+    // `crates/sui-types/src/unit_tests/crypto_tests.rs` in the main sui repo
+    // and is included as a regression vector against any future encoding
+    // drift.
+    #[cfg(feature = "bech32")]
+    mod bech32 {
+        use super::*;
+        use sui_sdk_types::SignatureScheme;
+
+        // Upstream test vector: `Ed25519KeyPair::generate(&mut StdRng::from_seed([0; 32]))`
+        // encoded with `SuiKeyPair::encode()` produces this string. The leading
+        // flag byte is 0x00 (Ed25519); the remaining 32 bytes are the private
+        // key.
+        const UPSTREAM_ED25519_SUIPRIVKEY: &str =
+            "suiprivkey1qzdlfxn2qa2lj5uprl8pyhexs02sg2wrhdy7qaq50cqgnffw4c2477kg9h3";
+
+        #[proptest]
+        fn ed25519_round_trip(signer: Ed25519PrivateKey) {
+            let encoded = signer.to_suiprivkey().unwrap();
+            let decoded = Ed25519PrivateKey::from_suiprivkey(&encoded).unwrap();
+            assert_eq!(decoded.public_key(), signer.public_key());
+
+            // SimpleKeypair dispatch agrees.
+            let keypair = SimpleKeypair::from_suiprivkey(&encoded).unwrap();
+            assert_eq!(keypair.scheme(), signer.scheme());
+            assert_eq!(encoded, keypair.to_suiprivkey().unwrap());
+        }
+
+        #[proptest]
+        fn secp256k1_round_trip(signer: Secp256k1PrivateKey) {
+            let encoded = signer.to_suiprivkey().unwrap();
+            let decoded = Secp256k1PrivateKey::from_suiprivkey(&encoded).unwrap();
+            assert_eq!(decoded.public_key(), signer.public_key());
+
+            let keypair = SimpleKeypair::from_suiprivkey(&encoded).unwrap();
+            assert_eq!(keypair.scheme(), signer.scheme());
+            assert_eq!(encoded, keypair.to_suiprivkey().unwrap());
+        }
+
+        #[proptest]
+        fn secp256r1_round_trip(signer: Secp256r1PrivateKey) {
+            let encoded = signer.to_suiprivkey().unwrap();
+            let decoded = Secp256r1PrivateKey::from_suiprivkey(&encoded).unwrap();
+            assert_eq!(decoded.public_key(), signer.public_key());
+
+            let keypair = SimpleKeypair::from_suiprivkey(&encoded).unwrap();
+            assert_eq!(keypair.scheme(), signer.scheme());
+            assert_eq!(encoded, keypair.to_suiprivkey().unwrap());
+        }
+
+        #[test]
+        fn upstream_ed25519_vector_round_trips() {
+            let keypair = SimpleKeypair::from_suiprivkey(UPSTREAM_ED25519_SUIPRIVKEY).unwrap();
+            assert_eq!(keypair.scheme(), SignatureScheme::Ed25519);
+            assert_eq!(
+                keypair.to_suiprivkey().unwrap(),
+                UPSTREAM_ED25519_SUIPRIVKEY
+            );
+
+            // Per-scheme decoder accepts it too.
+            Ed25519PrivateKey::from_suiprivkey(UPSTREAM_ED25519_SUIPRIVKEY).unwrap();
+            // Wrong-scheme per-scheme decoders reject it.
+            Secp256k1PrivateKey::from_suiprivkey(UPSTREAM_ED25519_SUIPRIVKEY).unwrap_err();
+            Secp256r1PrivateKey::from_suiprivkey(UPSTREAM_ED25519_SUIPRIVKEY).unwrap_err();
+        }
+
+        #[test]
+        fn rejects_wrong_hrp() {
+            // Same payload as the upstream Ed25519 vector but encoded with a
+            // different HRP — must fail.
+            let bytes = ::bech32::primitives::decode::CheckedHrpstring::new::<::bech32::Bech32>(
+                UPSTREAM_ED25519_SUIPRIVKEY,
+            )
+            .unwrap()
+            .byte_iter()
+            .collect::<Vec<_>>();
+            let wrong_hrp = ::bech32::Hrp::parse("notsui").unwrap();
+            let encoded = ::bech32::encode::<::bech32::Bech32>(wrong_hrp, &bytes).unwrap();
+
+            SimpleKeypair::from_suiprivkey(&encoded).unwrap_err();
+            Ed25519PrivateKey::from_suiprivkey(&encoded).unwrap_err();
+        }
+
+        #[test]
+        fn rejects_bech32m_checksum() {
+            // Re-encode the upstream Ed25519 payload using the Bech32m
+            // checksum variant. A correctly-implemented decoder must reject
+            // this, since the suipriv format uses BIP-173 Bech32 only.
+            let bytes = ::bech32::primitives::decode::CheckedHrpstring::new::<::bech32::Bech32>(
+                UPSTREAM_ED25519_SUIPRIVKEY,
+            )
+            .unwrap()
+            .byte_iter()
+            .collect::<Vec<_>>();
+            let hrp = ::bech32::Hrp::parse("suiprivkey").unwrap();
+            let bech32m = ::bech32::encode::<::bech32::Bech32m>(hrp, &bytes).unwrap();
+            assert_ne!(bech32m, UPSTREAM_ED25519_SUIPRIVKEY);
+
+            SimpleKeypair::from_suiprivkey(&bech32m).unwrap_err();
+            Ed25519PrivateKey::from_suiprivkey(&bech32m).unwrap_err();
+        }
     }
 }

--- a/crates/sui-crypto/src/suipriv.rs
+++ b/crates/sui-crypto/src/suipriv.rs
@@ -1,0 +1,61 @@
+//! Encoding and decoding helpers for the Sui `suiprivkey` Bech32 format.
+//!
+//! The format mirrors the one produced by the Sui CLI and the `sui-types`
+//! crate: a 33-byte payload of `flag || private_key` encoded as a Bech32
+//! (BIP-173) string with the human-readable part `suiprivkey`. The leading
+//! flag byte is the `SignatureScheme` flag for the contained key (`0x00` for
+//! Ed25519, `0x01` for Secp256k1, `0x02` for Secp256r1).
+//!
+//! These helpers are kept `pub(crate)` on purpose. Callers reach the format
+//! through strongly-typed wrappers like `Ed25519PrivateKey::from_suiprivkey`
+//! or `SimpleKeypair::from_suiprivkey` to avoid handing raw key bytes back as
+//! a `Vec<u8>` at the public boundary.
+
+use bech32::Bech32;
+use bech32::Hrp;
+use bech32::primitives::decode::CheckedHrpstring;
+use sui_sdk_types::SignatureScheme;
+
+use crate::SignatureError;
+
+/// The human-readable part of the `suiprivkey` Bech32 encoding.
+const HRP: &str = "suiprivkey";
+
+fn hrp() -> Hrp {
+    // "suiprivkey" is a valid Bech32 HRP (lowercase ASCII, length 10).
+    Hrp::parse(HRP).expect("`suiprivkey` is a valid Bech32 HRP")
+}
+
+/// Encode a `flag || private_key` payload as a Bech32 `suiprivkey` string.
+pub(crate) fn encode(scheme: SignatureScheme, key: &[u8]) -> Result<String, SignatureError> {
+    let mut payload = Vec::with_capacity(1 + key.len());
+    payload.push(scheme.to_u8());
+    payload.extend_from_slice(key);
+    bech32::encode::<Bech32>(hrp(), &payload)
+        .map_err(|e| SignatureError::from_source(format!("bech32 encode failed: {e}")))
+}
+
+/// Decode a Bech32 `suiprivkey` string into its scheme flag and key bytes.
+///
+/// The BIP-173 checksum is validated strictly; Bech32m-checksummed strings are
+/// rejected. The returned key bytes are everything after the flag byte and
+/// are not validated against the scheme — the caller is responsible for
+/// verifying the length and constructing a scheme-specific key from them.
+pub(crate) fn decode(s: &str) -> Result<(SignatureScheme, Vec<u8>), SignatureError> {
+    let parsed = CheckedHrpstring::new::<Bech32>(s)
+        .map_err(|e| SignatureError::from_source(format!("invalid suiprivkey string: {e}")))?;
+
+    if parsed.hrp() != hrp() {
+        return Err(SignatureError::from_source(format!(
+            "expected `{HRP}` human-readable part",
+        )));
+    }
+
+    let bytes: Vec<u8> = parsed.byte_iter().collect();
+    let (flag, key) = bytes
+        .split_first()
+        .ok_or_else(|| SignatureError::from_source("suipriv payload is empty"))?;
+    let scheme = SignatureScheme::from_byte(*flag)
+        .map_err(|e| SignatureError::from_source(format!("invalid suipriv scheme flag: {e}")))?;
+    Ok((scheme, key.to_vec()))
+}


### PR DESCRIPTION
Add a new `bech32` feature to `sui-crypto` that exposes `from_suiprivkey` and `to_suiprivkey` on `SimpleKeypair` and on each of `Ed25519PrivateKey`, `Secp256k1PrivateKey`, and `Secp256r1PrivateKey`. Previously there was no way to load a private key produced by the Sui CLI or the legacy SDK; with this commit we accept the same `suiprivkey` Bech32 (BIP-173) encoding that `sui-types` and `sui-keys` use upstream.

The format encodes a 33-byte payload of `flag || private_key` with the human-readable part `suiprivkey`, where the flag byte matches the `SignatureScheme` of the contained key. Decoding strictly enforces the BIP-173 checksum (rejecting Bech32m), the `suiprivkey` HRP, and that the flag corresponds to one of the three simple schemes — matching the upstream parser. Per-scheme decoders additionally reject any flag that does not match their own scheme.

Encoding and decoding share an internal `suipriv` helper module rather than exposing a raw `(SignatureScheme, Vec<u8>)` API, so callers always receive a strongly-typed key. Tests cover round-trips for each scheme, the upstream Ed25519 known-answer vector from the main sui repo, and rejection of wrong-HRP and Bech32m-checksummed inputs.

Closes #201.