### PR TITLE
sui-sdk-types: reject `Address::from_hex("0x")` as empty input

### DIFF
--- a/crates/sui-sdk-types/src/address.rs
+++ b/crates/sui-sdk-types/src/address.rs
@@ -279,6 +279,15 @@ const fn hex_address_bytes(bytes: &[u8]) -> Result<[u8; Address::LENGTH], HexDec
         return Err(HexDecodeError::EmptyInput);
     }
     let hex = remove_0x_prefix(bytes);
+    // A bare `"0x"` is semantically the same as an empty input: there are
+    // no hex digits to decode. Without this check the function would
+    // silently return `Address::ZERO`, which is inconsistent with the
+    // already-rejected empty-input case and turns a typo (e.g. embedding
+    // `Address::from_static("0x")` instead of the intended literal) into
+    // a silent zero address rather than a compile-time panic.
+    if hex.is_empty() {
+        return Err(HexDecodeError::EmptyInput);
+    }
     if hex.len() > 64 {
         return Err(HexDecodeError::InputTooLong(hex.len()));
     }
@@ -380,5 +389,48 @@ mod test {
         let s = address.to_string();
         let a = s.parse::<Address>().unwrap();
         assert_eq!(address, a);
+    }
+
+    // Regression: a bare `"0x"` used to decode to `Address::ZERO` while the
+    // empty string `""` was rejected with `EmptyInput`. The two inputs are
+    // semantically identical (both contain zero hex digits) and so should
+    // produce the same outcome. Without this check, a typo such as
+    // `Address::from_static("0x")` — meant to be a real address literal but
+    // accidentally truncated — would silently produce the zero address
+    // instead of a clear compile-time panic, and `Address::from_hex("0x")`
+    // would silently succeed at runtime.
+    #[test]
+    fn rejects_empty_after_strip() {
+        let bare_prefix = Address::from_hex("0x");
+        let empty = Address::from_hex("");
+        assert!(
+            bare_prefix.is_err(),
+            "`0x` must be rejected like empty input"
+        );
+        assert!(empty.is_err());
+        assert_eq!(bare_prefix.unwrap_err(), empty.unwrap_err());
+    }
+
+    #[test]
+    fn rejects_empty_input() {
+        assert!(Address::from_hex("").is_err());
+    }
+
+    // `Address::from_static` is a `const fn` that unwraps the result of
+    // `hex_address_bytes`. A bare `"0x"` literal must therefore panic at
+    // const-evaluation rather than silently produce `Address::ZERO`.
+    #[test]
+    #[should_panic(expected = "input hex string must be non-empty")]
+    fn from_static_bare_prefix_panics() {
+        let _ = Address::from_static("0x");
+    }
+
+    // Sanity: real hex literals (including odd-length and minimal) still
+    // round-trip as before.
+    #[test]
+    fn short_hex_inputs_still_parse() {
+        for s in ["0x0", "0x1", "0x00", "0xf", "0xff"] {
+            assert!(Address::from_hex(s).is_ok(), "expected {s} to parse");
+        }
     }
 }


### PR DESCRIPTION
## Why

`hex_address_bytes` checks for an empty byte slice up front, but then runs `remove_0x_prefix` and continues through the decode loop without re-checking emptiness. As a result the two semantically identical inputs are handled inconsistently:

| Input  | Old behaviour                              | New behaviour    |
|--------|--------------------------------------------|------------------|
| `""`   | `Err(EmptyInput)`                          | `Err(EmptyInput)` |
| `"0x"` | `Ok(Address::ZERO)` — silent zero address  | `Err(EmptyInput)` |

For runtime callers (`Address::from_hex("0x")`) this masked malformed input as a successful parse to the zero address — a value that has real on-chain meaning. For `const` callers (`Address::from_static("0x")`) it turned a typo — meant to be a real 64-char address literal but accidentally truncated to just the prefix — into a silent `Address::ZERO` rather than the compile-time panic the empty-input path already produces (`input hex string must be non-empty`).

This is the same flavor of canonical-encoding tightening as the recently-merged hardening series (`reject trailing bytes when decoding Bitmap`, `reject non-canonical MoveStructType encodings`, `reject non-canonical Bn254FieldElement encodings`, etc.): one logical value should have exactly one accepted representation, and edge-case typos should fail loudly rather than silently round-trip to a defensible-looking default.

## What

`hex_address_bytes`: after `remove_0x_prefix`, re-check `hex.is_empty()` and return the existing `HexDecodeError::EmptyInput` variant. This routes both `Address::from_hex("")` and `Address::from_hex("0x")` to the same error, and makes `Address::from_static("0x")` panic at const-evaluation with the existing `"input hex string must be non-empty"` message via `HexDecodeError::const_panic`.

No new error variants or public API changes.

## Tests

Added four focused tests in `crates/sui-sdk-types/src/address.rs`:

- `rejects_empty_after_strip` — `from_hex("0x")` errors with the same `AddressParseError` as `from_hex("")`.
- `rejects_empty_input` — explicit coverage of the pre-existing empty-string path.
- `from_static_bare_prefix_panics` — `#[should_panic(expected = "input hex string must be non-empty")]` regression test for the `const` path.
- `short_hex_inputs_still_parse` — sanity that `"0x0"`, `"0x1"`, `"0x00"`, `"0xf"`, `"0xff"` continue to parse exactly as before, so the bound only catches the genuinely-empty case.

Validation:

- `cargo test -p sui-sdk-types --all-features` — 293 unit + 15 doctests pass.
- `cargo clippy -p sui-sdk-types --all-features --lib --tests -- -D warnings` — clean.
- `cargo fmt --check -p sui-sdk-types` — clean.
- `cargo check --workspace --all-features` — clean.

## Compatibility

Technically a behaviour change: any caller that today relies on `Address::from_hex("0x") -> Address::ZERO` will get an error after this patch. A quick scan of the repo turned up no such caller (all string-literal call sites use either non-prefix-only literals or the explicit `Address::ZERO` constant), and the previous behaviour was almost certainly unintended given the empty-input path already exists. If a caller does want the zero address from an empty input, the explicit constructors (`Address::ZERO`, `Address::from_bytes(&[0; 32])`) are unambiguous.

## Out of scope

- The hex decoder still accepts odd-length inputs and right-aligns them (e.g. `"0x1" -> 0x...01`); this PR preserves that behaviour and only tightens the zero-digit case.
- Uppercase `0X` prefixes are still rejected as invalid hex characters, unchanged.