### PR TITLE
sui-rpc: fold authenticated events per settlement, not per checkpoint

### DIFF
--- a/crates/sui-rpc/src/light_client/events/client.rs
+++ b/crates/sui-rpc/src/light_client/events/client.rs
@@ -12,23 +12,32 @@ use tokio::sync::mpsc;
 use super::config::AuthenticatedEventsConfig;
 use super::envelope::AuthenticatedEvent;
 use super::state::StreamState;
+use super::state::buffer_response_batch;
 use super::state::extract_event_stream_head;
-use super::state::process_response_batch;
-use super::state::reconcile_local_head;
+use super::state::fold_and_reconcile;
 use crate::light_client::CheckpointObjectProof;
 use crate::light_client::LightClient;
 use crate::light_client::error::LightClientError;
+use crate::proto::sui::rpc::v2alpha::AffectedObjectFilter;
 use crate::proto::sui::rpc::v2alpha::EventFilter;
 use crate::proto::sui::rpc::v2alpha::EventLiteral;
 use crate::proto::sui::rpc::v2alpha::EventPredicate;
 use crate::proto::sui::rpc::v2alpha::EventStreamHeadFilter;
 use crate::proto::sui::rpc::v2alpha::EventTerm;
 use crate::proto::sui::rpc::v2alpha::ListEventsRequest;
+use crate::proto::sui::rpc::v2alpha::ListTransactionsRequest;
 use crate::proto::sui::rpc::v2alpha::QueryEndReason;
 use crate::proto::sui::rpc::v2alpha::QueryOptions;
+use crate::proto::sui::rpc::v2alpha::TransactionFilter;
+use crate::proto::sui::rpc::v2alpha::TransactionLiteral;
+use crate::proto::sui::rpc::v2alpha::TransactionPredicate;
+use crate::proto::sui::rpc::v2alpha::TransactionTerm;
 use crate::proto::sui::rpc::v2alpha::event_literal;
 use crate::proto::sui::rpc::v2alpha::event_predicate;
 use crate::proto::sui::rpc::v2alpha::list_events_response;
+use crate::proto::sui::rpc::v2alpha::list_transactions_response;
+use crate::proto::sui::rpc::v2alpha::transaction_literal;
+use crate::proto::sui::rpc::v2alpha::transaction_predicate;
 
 /// A streaming verifier for a single authenticated event stream.
 ///
@@ -77,11 +86,14 @@ impl AuthenticatedEventsClient {
 /// `latest_checkpoint + 1`. Either way the floor ensures no event can
 /// land in the interval without being picked up by the head check.
 ///
-/// Steady state: page through `ListEvents`, fold each page into the
-/// local MMR, and at each [`AuthenticatedEventsConfig::head_check_interval`]
-/// tick fetch the on-chain head and reconcile. On match, drain the
-/// confirmed events through the channel. On mismatch, send the error
-/// and exit.
+/// Steady state: page through `ListEvents` and buffer the items, then at
+/// each [`AuthenticatedEventsConfig::head_check_interval`] tick fetch
+/// the settlement boundaries for the unconfirmed range via
+/// `ListTransactions(affected_object = event_stream_head)`, fold the
+/// buffered events into the local MMR partitioned by settlement, and
+/// reconcile the resulting head against the on-chain head proven at the
+/// last settled checkpoint. On match, drain the confirmed events
+/// through the channel. On mismatch, send the error and exit.
 async fn run_stream_task(
     mut light: LightClient,
     config: AuthenticatedEventsConfig,
@@ -111,13 +123,18 @@ async fn run_stream_task(
 
     loop {
         // Decide whether to fetch the next page or reconcile.
+        //
+        // The "idle" condition (non-empty buffer, no cursor, drained
+        // through the next checkpoint) lets us reconcile as soon as
+        // we've drawn level with the indexed tip rather than waiting
+        // out the full interval.
         let should_reconcile = last_head_check.elapsed() >= config.head_check_interval
-            || !state.pending.is_empty()
+            || !state.buffer.is_empty()
                 && next_cursor.is_none()
                 && page_drain_done(&state, next_checkpoint);
 
         if should_reconcile {
-            match reconcile_once(&mut light, &mut state, &stream_head_object_id).await {
+            match reconcile_once(&mut light, &mut state, &stream_head_object_id, &config).await {
                 Ok(released) => {
                     consecutive_failures = 0;
                     last_head_check = std::time::Instant::now();
@@ -160,23 +177,21 @@ async fn run_stream_task(
                     events,
                     end_cursor,
                     end_reason,
+                    watermark_hi,
                     partial_error,
                 } = page;
 
-                if let Err(e) = process_response_batch(&mut state, events) {
-                    let _ = tx.send(Err(e)).await;
-                    return;
-                }
+                buffer_response_batch(&mut state, events, watermark_hi);
 
                 // Mid-stream transport error: commit whatever items we
-                // got into the MMR (done above), advance `next_cursor`
-                // to the latest watermark the server sent, then
-                // backoff-or-give-up the same way a pre-stream error
-                // would. This is the fix for the resumption-on-timeout
-                // case: without it, repeated server-side timeouts would
-                // each lose the cursor accumulated during the failed
-                // page and the loop would replay the same stale
-                // position forever.
+                // got into the buffer (done above), advance
+                // `next_cursor` to the latest watermark the server
+                // sent, then backoff-or-give-up the same way a
+                // pre-stream error would. This is the fix for the
+                // resumption-on-timeout case: without it, repeated
+                // server-side timeouts would each lose the cursor
+                // accumulated during the failed page and the loop
+                // would replay the same stale position forever.
                 if let Some(err) = partial_error {
                     if e_is_retryable(&err) {
                         next_cursor = end_cursor;
@@ -193,26 +208,31 @@ async fn run_stream_task(
                 consecutive_failures = 0;
                 match end_reason {
                     // The server stopped mid-range with unscanned work
-                    // remaining — resume from the latest in-stream cursor
-                    // (item or watermark) so we don't skip the unscanned
-                    // tail. Same shape as ItemLimit: keep advancing the
-                    // cursor, no checkpoint bump, no backoff sleep.
+                    // remaining — resume from the latest in-stream
+                    // cursor (item or watermark) so we don't skip the
+                    // unscanned tail. Same shape as ItemLimit: keep
+                    // advancing the cursor, no checkpoint bump, no
+                    // backoff sleep.
                     Some(QueryEndReason::ItemLimit | QueryEndReason::ScanLimit) => {
                         next_cursor = end_cursor;
                     }
                     Some(_) => {
                         // Server reached the indexed tip, a requested
-                        // checkpoint range bound, or a cursor bound — no
-                        // more events available in this scan. Reset cursor
-                        // and bump start checkpoint to one past the latest
-                        // fold so the next page picks up new events as
-                        // they arrive.
+                        // checkpoint range bound, or a cursor bound —
+                        // no more events available in this scan. Reset
+                        // cursor and bump start checkpoint to one past
+                        // the watermark / last buffered event so the
+                        // next page picks up new events as they
+                        // arrive. We can't use `local_head.checkpoint_seq`
+                        // here because folding is deferred to
+                        // reconciliation — it can lag the scan by an
+                        // entire interval.
                         next_cursor = None;
                         next_checkpoint = state
-                            .local_head
-                            .checkpoint_seq
+                            .events_scanned_through
                             .checked_add(1)
-                            .unwrap_or(next_checkpoint);
+                            .unwrap_or(next_checkpoint)
+                            .max(next_checkpoint);
                         // Sleep briefly so we don't spin when at the tip.
                         tokio::time::sleep(config.retry_backoff).await;
                     }
@@ -311,6 +331,11 @@ struct PageResult {
     /// the server no longer carries a cursor on `QueryEnd`.
     end_cursor: Option<prost::bytes::Bytes>,
     end_reason: Option<QueryEndReason>,
+    /// Most recent `Watermark.checkpoint_hi` observed in this page,
+    /// across both standalone watermarks and per-item watermarks. The
+    /// streaming state uses this as the "events scanned through" floor
+    /// when picking the settlement-fetch range.
+    watermark_hi: Option<u64>,
     /// Mid-stream transport error that interrupted page accumulation.
     /// When present, `events` and `end_cursor` reflect what was
     /// received before the error. The caller advances `next_cursor` to
@@ -335,6 +360,7 @@ async fn fetch_one_page(
     let mut events = Vec::new();
     let mut end_cursor: Option<prost::bytes::Bytes> = None;
     let mut end_reason = None;
+    let mut watermark_hi: Option<u64> = None;
     let mut partial_error: Option<LightClientError> = None;
 
     while let Some(frame) = stream.next().await {
@@ -347,8 +373,13 @@ async fn fetch_one_page(
         };
         match frame.response {
             Some(list_events_response::Response::Item(item)) => {
-                if let Some(c) = item.watermark.as_ref().and_then(|w| w.cursor.clone()) {
-                    end_cursor = Some(c);
+                if let Some(w) = item.watermark.as_ref() {
+                    if let Some(c) = w.cursor.clone() {
+                        end_cursor = Some(c);
+                    }
+                    if let Some(hi) = w.checkpoint_hi {
+                        watermark_hi = Some(watermark_hi.map_or(hi, |prev| prev.max(hi)));
+                    }
                 }
                 let ev = AuthenticatedEvent::try_from(&item)?;
                 events.push(ev);
@@ -356,6 +387,9 @@ async fn fetch_one_page(
             Some(list_events_response::Response::Watermark(w)) => {
                 if let Some(c) = w.cursor {
                     end_cursor = Some(c);
+                }
+                if let Some(hi) = w.checkpoint_hi {
+                    watermark_hi = Some(watermark_hi.map_or(hi, |prev| prev.max(hi)));
                 }
             }
             Some(list_events_response::Response::End(end)) => {
@@ -370,46 +404,206 @@ async fn fetch_one_page(
         events,
         end_cursor,
         end_reason,
+        watermark_hi,
         partial_error,
     })
 }
 
+/// Drive one reconciliation tick: fetch settlements for the unconfirmed
+/// range, fold the buffered events through the latest settled
+/// checkpoint into the local MMR, prove the on-chain head at that
+/// checkpoint, and release the folded events on a match.
+///
+/// Returns the released events on success. Returns `Ok(Vec::new())`
+/// when there's nothing to reconcile yet (the head wasn't modified
+/// anywhere in the unconfirmed range, so there's no chain anchor to
+/// compare against).
 async fn reconcile_once(
     light: &mut LightClient,
     state: &mut StreamState,
     stream_head_object_id: &sui_sdk_types::Address,
+    config: &AuthenticatedEventsConfig,
 ) -> Result<Vec<AuthenticatedEvent>, LightClientError> {
-    let tip = light.latest_checkpoint_seq().await?;
+    // Settlements only happen up through events we've fully scanned —
+    // querying past `events_scanned_through` risks partitioning into a
+    // settlement bucket whose events haven't all been buffered yet.
+    let settlement_upper_inclusive = state.events_scanned_through;
+    if settlement_upper_inclusive <= state.confirmed_through {
+        return Ok(Vec::new());
+    }
+
+    let settlements = fetch_settlements_for_range(
+        light,
+        stream_head_object_id,
+        state.confirmed_through.saturating_add(1),
+        settlement_upper_inclusive.saturating_add(1),
+        config.page_size,
+    )
+    .await?;
+
+    let Some((reconcile_cp, _)) = settlements.last().copied() else {
+        // No settlement in the unconfirmed range — the head wasn't
+        // modified, so there's no anchor to reconcile against. Pending
+        // events stay buffered; the next reconciliation tick will
+        // retry once a settlement lands.
+        return Ok(Vec::new());
+    };
+
     let proof = light
-        .prove_object_at_checkpoint(stream_head_object_id, tip)
+        .prove_object_at_checkpoint(stream_head_object_id, reconcile_cp)
         .await?;
-    match proof {
+    let chain_head = match proof {
         CheckpointObjectProof::Inclusion {
             object: Some(object),
             ..
-        } => {
-            let chain_head = extract_event_stream_head(&object)?;
-            reconcile_local_head(state, chain_head)
-        }
+        } => extract_event_stream_head(&object)?,
         CheckpointObjectProof::Inclusion { object: None, .. } => {
-            // The on-chain head was deleted or wrapped at the tip.
-            // The local replay cannot be reconciled against a missing
-            // head; this is terminal for the stream.
-            Err(LightClientError::UnexpectedObjectShape {
+            // The on-chain head was deleted or wrapped at the
+            // settlement checkpoint. The local replay cannot be
+            // reconciled against a missing head; this is terminal for
+            // the stream.
+            return Err(LightClientError::UnexpectedObjectShape {
                 reason: "event stream head was deleted or wrapped at the reconciliation tip",
-            })
+            });
         }
-        // The head wasn't modified at the tip: there is no fresh
-        // on-chain head to reconcile against, so we can't confirm any
-        // additional events here. Pending events stay pending; the
-        // next reconciliation tick will retry.
-        //
-        // This is the success-path equivalent of the old code's
-        // `NotFound` error at reconcile time: today the stream would
-        // have terminated; now we let it idle until a checkpoint
-        // actually touches the head.
-        CheckpointObjectProof::NonInclusion => Ok(Vec::new()),
+        CheckpointObjectProof::NonInclusion => {
+            // `ListTransactions(affected_object)` placed a settlement
+            // at this checkpoint, but the OCS proof says the head
+            // wasn't modified there — the two indexes are
+            // inconsistent.
+            return Err(LightClientError::UnexpectedObjectShape {
+                reason: "settlement transaction listed at checkpoint but OCS proof reports \
+                         the event stream head was not modified",
+            });
+        }
+    };
+
+    fold_and_reconcile(state, &settlements, chain_head, reconcile_cp)
+}
+
+/// Page through `ListTransactions` filtered on `affected_object =
+/// stream_head_object_id` and return the ascending `(checkpoint,
+/// transaction_offset)` settlement boundaries for `[start, end)`.
+///
+/// Each `settle_events` transaction mutates the stream's head object,
+/// so this filter returns exactly the per-stream settlement boundaries.
+/// `start` is inclusive and `end` is exclusive — matching the proto
+/// `start_checkpoint` / `end_checkpoint` semantics — so the caller
+/// passes `confirmed_through + 1` and `events_scanned_through + 1`.
+async fn fetch_settlements_for_range(
+    light: &mut LightClient,
+    stream_head_object_id: &sui_sdk_types::Address,
+    start_checkpoint: u64,
+    end_checkpoint_exclusive: u64,
+    page_size: u32,
+) -> Result<Vec<(u64, u64)>, LightClientError> {
+    if end_checkpoint_exclusive <= start_checkpoint {
+        return Ok(Vec::new());
     }
+
+    let filter = build_affected_object_filter(stream_head_object_id);
+    let mut settlements: Vec<(u64, u64)> = Vec::new();
+    let mut cursor: Option<prost::bytes::Bytes> = None;
+
+    loop {
+        let request = ListTransactionsRequest {
+            read_mask: None,
+            start_checkpoint: Some(start_checkpoint),
+            end_checkpoint: Some(end_checkpoint_exclusive),
+            filter: Some(filter.clone()),
+            options: Some(QueryOptions {
+                limit_items: Some(page_size),
+                after: cursor.clone(),
+                before: None,
+                ordering: 0, // ascending
+            }),
+        };
+
+        let page = fetch_settlements_page(light, request).await?;
+        settlements.extend(page.entries);
+
+        match page.end_reason {
+            // Server hit its per-request bound but the range may have
+            // more — keep paging from the latest cursor it gave us.
+            Some(QueryEndReason::ItemLimit | QueryEndReason::ScanLimit) => {
+                if page.end_cursor.is_none() {
+                    // Defensive: no cursor advance means we'd loop
+                    // forever. Treat as done; the next reconciliation
+                    // tick will retry with a fresh window.
+                    break;
+                }
+                cursor = page.end_cursor;
+            }
+            // Range fully scanned (CheckpointBound / CursorBound /
+            // LedgerTip / Unspecified) or end frame missing: nothing
+            // more to fetch in this window.
+            _ => break,
+        }
+    }
+
+    Ok(settlements)
+}
+
+struct SettlementsPage {
+    entries: Vec<(u64, u64)>,
+    end_cursor: Option<prost::bytes::Bytes>,
+    end_reason: Option<QueryEndReason>,
+}
+
+async fn fetch_settlements_page(
+    light: &mut LightClient,
+    request: ListTransactionsRequest,
+) -> Result<SettlementsPage, LightClientError> {
+    let mut stream = light
+        .rpc()
+        .ledger_client_alpha()
+        .list_transactions(request)
+        .await?
+        .into_inner();
+
+    let mut entries = Vec::new();
+    let mut end_cursor: Option<prost::bytes::Bytes> = None;
+    let mut end_reason = None;
+
+    while let Some(frame) = stream.next().await {
+        let frame = frame?;
+        match frame.response {
+            Some(list_transactions_response::Response::Item(item)) => {
+                if let Some(c) = item.watermark.as_ref().and_then(|w| w.cursor.clone()) {
+                    end_cursor = Some(c);
+                }
+                let checkpoint = item
+                    .transaction
+                    .as_ref()
+                    .and_then(|tx| tx.checkpoint)
+                    .ok_or(LightClientError::UnexpectedObjectShape {
+                        reason: "settlement transaction missing checkpoint",
+                    })?;
+                let tx_offset =
+                    item.transaction_offset
+                        .ok_or(LightClientError::UnexpectedObjectShape {
+                            reason: "settlement transaction missing transaction_offset",
+                        })?;
+                entries.push((checkpoint, tx_offset));
+            }
+            Some(list_transactions_response::Response::Watermark(w)) => {
+                if let Some(c) = w.cursor {
+                    end_cursor = Some(c);
+                }
+            }
+            Some(list_transactions_response::Response::End(end)) => {
+                end_reason = QueryEndReason::try_from(end.reason).ok();
+                break;
+            }
+            None => break,
+        }
+    }
+
+    Ok(SettlementsPage {
+        entries,
+        end_cursor,
+        end_reason,
+    })
 }
 
 fn build_filter(stream_id_hex: &str) -> EventFilter {
@@ -428,10 +622,28 @@ fn build_filter(stream_id_hex: &str) -> EventFilter {
     }
 }
 
-/// True if pending events were already drained up through the last
-/// folded checkpoint, so we're idle and may as well reconcile sooner.
+fn build_affected_object_filter(object_id: &sui_sdk_types::Address) -> TransactionFilter {
+    TransactionFilter {
+        terms: vec![TransactionTerm {
+            literals: vec![TransactionLiteral {
+                polarity: Some(transaction_literal::Polarity::Include(
+                    TransactionPredicate {
+                        predicate: Some(transaction_predicate::Predicate::AffectedObject(
+                            AffectedObjectFilter {
+                                object_id: Some(object_id.to_string()),
+                            },
+                        )),
+                    },
+                )),
+            }],
+        }],
+    }
+}
+
+/// True if buffered events were already scanned up through `next_checkpoint`,
+/// so the page-fetch loop is idle and may as well reconcile sooner.
 fn page_drain_done(state: &StreamState, next_checkpoint: u64) -> bool {
-    state.local_head.checkpoint_seq < next_checkpoint
+    state.events_scanned_through.saturating_add(1) >= next_checkpoint
 }
 
 fn e_is_retryable(err: &LightClientError) -> bool {

--- a/crates/sui-rpc/src/light_client/events/state.rs
+++ b/crates/sui-rpc/src/light_client/events/state.rs
@@ -1,9 +1,12 @@
 //! Pure verification helpers for the streaming client.
 //!
 //! Factored out of the spawned task so they can be unit-tested without
-//! standing up an RPC harness. The task in `client` calls
-//! [`process_response_batch`] for each incoming page of events and
-//! [`reconcile_local_head`] each time a fresh on-chain head is fetched.
+//! standing up an RPC harness. The streaming task in `client` calls
+//! [`buffer_response_batch`] for each incoming page of events and
+//! [`fold_and_reconcile`] each reconciliation tick — passing in the
+//! settlement boundaries fetched from `ListTransactions(affected_object =
+//! event_stream_head)` so events are folded into the local MMR in the
+//! same per-settlement partitions the framework used on chain.
 
 use std::collections::VecDeque;
 
@@ -19,119 +22,251 @@ use crate::light_client::error::MmrMismatch;
 
 /// In-memory state the streaming task carries across iterations of the
 /// list-events / reconcile loop.
+///
+/// Events are buffered (not folded) as `ListEvents` pages arrive: the
+/// framework can run multiple `settle_events` transactions per
+/// checkpoint (one per consensus commit per stream), and folding events
+/// into the wrong settlement bucket produces an MMR shape that will
+/// never match the on-chain head. The buffer is flushed at
+/// reconciliation time, once `ListTransactions(affected_object =
+/// event_stream_head)` has surfaced the per-settlement boundaries.
 #[derive(Debug, Default)]
 pub(super) struct StreamState {
-    /// Events that have been folded into `local_head` but not yet
-    /// reconciled against an on-chain head. Once reconciliation
-    /// succeeds at a checkpoint, every entry with
-    /// `checkpoint <= reconciled_checkpoint` is released to the
-    /// consumer and drained from this queue.
-    pub pending: VecDeque<AuthenticatedEvent>,
+    /// Events received from `ListEvents` but not yet folded into
+    /// [`Self::local_head`]. Once a reconciliation tick succeeds, every
+    /// entry with `checkpoint <= reconciled_checkpoint` is folded into
+    /// the local MMR, released to the consumer, and drained from this
+    /// queue.
+    ///
+    /// Items are stored in receipt order — which matches strictly
+    /// ascending `(checkpoint, transaction_offset, event_index)` per the
+    /// v2alpha contract.
+    pub buffer: VecDeque<AuthenticatedEvent>,
 
-    /// The MMR head we've replayed by folding each received event.
-    /// Compared byte-for-byte against the on-chain head during
-    /// reconciliation.
+    /// The MMR head we've replayed by folding the settlement-partitioned
+    /// event batches. Compared byte-for-byte against the on-chain head
+    /// during reconciliation.
     pub local_head: EventStreamHead,
 
     /// The most recent checkpoint at which `local_head` was confirmed
-    /// to match the on-chain head. Subsequent reconciliations only
-    /// need to validate events folded *after* this point.
+    /// to match the on-chain head. Subsequent reconciliations only need
+    /// to fold events landed strictly after this point.
     pub confirmed_through: u64,
+
+    /// Highest checkpoint number whose events `ListEvents` has fully
+    /// emitted to us, derived from the latest `Watermark.checkpoint_hi`
+    /// across both standalone watermarks and per-item watermarks.
+    ///
+    /// Reconciliation uses this as the upper bound when fetching
+    /// settlements: settlements at checkpoints we haven't fully scanned
+    /// for events would otherwise produce an empty fold (with the head
+    /// stamping a different `num_events`) and fail reconciliation.
+    pub events_scanned_through: u64,
 }
 
 impl StreamState {
     pub(super) fn new(initial_head: EventStreamHead, confirmed_through: u64) -> Self {
         Self {
-            pending: VecDeque::new(),
+            buffer: VecDeque::new(),
             local_head: initial_head,
             confirmed_through,
+            events_scanned_through: confirmed_through,
         }
     }
 }
 
-/// Group `events` by `checkpoint`, fold each non-empty group into the
-/// state's local MMR via [`apply_stream_updates`], and push the events
-/// onto `state.pending` in receipt order.
+/// Append `events` to `state.buffer` and advance
+/// `state.events_scanned_through` to `watermark_hi.max(events.last())` if
+/// either is greater than the current value.
 ///
-/// `events` must be in ascending
-/// `(checkpoint, transaction_offset, event_index)` order with respect
-/// to each other and to `state.local_head.checkpoint_seq`. The server
-/// guarantees this for `ListEvents` responses; the function is
-/// strict about it so a malformed server response is caught at the
-/// fold step rather than during reconciliation.
+/// `events` must be in strictly ascending
+/// `(checkpoint, transaction_offset, event_index)` order with respect to
+/// each other and to whatever's already at the back of `state.buffer` —
+/// the v2alpha contract guarantees this for `ListEvents` responses, and
+/// the fold-time partitioner relies on it. Empty input is a no-op.
 ///
-/// Returns `Ok(())` on success, or propagates an error from the
-/// underlying MMR fold.
-pub(super) fn process_response_batch(
+/// `watermark_hi` is the most recent `Watermark.checkpoint_hi` observed
+/// during this page, including the watermark embedded on the last item.
+/// Pass `None` when the page produced neither a standalone watermark nor
+/// an item-embedded one (e.g., an immediate `End` frame at genesis).
+pub(super) fn buffer_response_batch(
     state: &mut StreamState,
     events: Vec<AuthenticatedEvent>,
-) -> Result<(), LightClientError> {
-    if events.is_empty() {
-        return Ok(());
+    watermark_hi: Option<u64>,
+) {
+    let last_event_cp = events.last().map(|e| e.checkpoint);
+    for event in events {
+        state.buffer.push_back(event);
     }
 
-    // Group consecutive events by checkpoint while preserving order.
+    if let Some(hi) = watermark_hi {
+        state.events_scanned_through = state.events_scanned_through.max(hi);
+    }
+    if let Some(cp) = last_event_cp {
+        // Defensive: even if no watermark frame surfaced for this page,
+        // every emitted event implies the scan reached its checkpoint.
+        state.events_scanned_through = state.events_scanned_through.max(cp);
+    }
+}
+
+/// Partition the events at the front of `state.buffer` by settlement,
+/// fold each partition into `state.local_head`, and reconcile the
+/// updated head against `chain_head` at the last settlement's
+/// checkpoint.
+///
+/// `settlements` is the ascending sequence of `(checkpoint,
+/// transaction_offset)` pairs from `ListTransactions(affected_object =
+/// event_stream_head)`, covering `(state.confirmed_through,
+/// reconcile_checkpoint]`. `reconcile_checkpoint` is the checkpoint at
+/// which `chain_head` was authenticated — by construction the
+/// checkpoint of the last entry in `settlements`.
+///
+/// Each event in the partitioned prefix is assigned to the next
+/// settlement whose `(cp, tx_offset)` lies at-or-after the event's
+/// position, and a settlement reject is a hard error (it indicates the
+/// stream's `ListEvents` and `ListTransactions` indexes have diverged).
+///
+/// On a matching reconciliation: drains the folded events from
+/// `state.buffer`, advances `state.confirmed_through` to
+/// `reconcile_checkpoint`, and returns the released events in receipt
+/// order. On any mismatch: returns the error without mutating the
+/// observable parts of `state` — the caller should abort the stream.
+pub(super) fn fold_and_reconcile(
+    state: &mut StreamState,
+    settlements: &[(u64, u64)],
+    chain_head: EventStreamHead,
+    reconcile_checkpoint: u64,
+) -> Result<Vec<AuthenticatedEvent>, LightClientError> {
+    // Settlements must be non-empty and the last one's checkpoint must
+    // equal the reconciliation point — that's the load-bearing invariant
+    // the caller is contracted to uphold.
+    let last_settlement =
+        settlements
+            .last()
+            .copied()
+            .ok_or(LightClientError::UnexpectedObjectShape {
+                reason: "fold_and_reconcile called with no settlements; \
+                     reconciliation needs at least one settlement to anchor the chain head",
+            })?;
+    if last_settlement.0 != reconcile_checkpoint {
+        return Err(LightClientError::UnexpectedObjectShape {
+            reason: "settlement boundaries disagree with reconciliation checkpoint",
+        });
+    }
+
+    // Count the buffered events whose checkpoint lies at or below the
+    // reconciliation point — these are the ones we'll partition and
+    // fold. Anything past `reconcile_checkpoint` stays buffered for the
+    // next round.
+    let fold_count = state
+        .buffer
+        .iter()
+        .take_while(|e| e.checkpoint <= reconcile_checkpoint)
+        .count();
+
+    let batches = bucket_events_by_settlement(
+        state.buffer.iter().take(fold_count),
+        settlements,
+        state.confirmed_through,
+    )?;
+
+    let new_head =
+        apply_stream_updates(state.local_head.clone(), &batches).map_err(LightClientError::from)?;
+
+    if new_head != chain_head {
+        return Err(LightClientError::MmrMismatch(Box::new(MmrMismatch {
+            checkpoint: reconcile_checkpoint,
+            expected: chain_head,
+            actual: new_head,
+        })));
+    }
+
+    // Reconciliation succeeded: commit the fold and drain the released
+    // events.
+    state.local_head = new_head;
+    state.confirmed_through = reconcile_checkpoint;
+    let released: Vec<AuthenticatedEvent> = state.buffer.drain(..fold_count).collect();
+    Ok(released)
+}
+
+/// Bucket `events` into per-settlement [`EventBatch`]es using the
+/// ascending `settlements` boundary list. Returns an empty `Vec` only if
+/// `events` is empty after the `floor_checkpoint` filter — every kept
+/// event must map to a settlement at its own checkpoint, or the function
+/// errors.
+///
+/// Mirrors the upstream e2e helper that drives the on-chain
+/// reconciliation: each event maps to the first settlement with `(cp ==
+/// event.cp, tx_offset >= event.tx_offset)`, and events sharing a
+/// settlement key form a single batch.
+fn bucket_events_by_settlement<'a, I>(
+    events: I,
+    settlements: &[(u64, u64)],
+    floor_checkpoint: u64,
+) -> Result<Vec<EventBatch>, LightClientError>
+where
+    I: IntoIterator<Item = &'a AuthenticatedEvent>,
+{
     let mut batches: Vec<EventBatch> = Vec::new();
-    for event in &events {
+    let mut current_key: Option<(u64, u64)> = None;
+    let mut settlement_idx: usize = 0;
+
+    for event in events {
+        // Skip events that fall at-or-below the floor — those have
+        // already been folded into `state.local_head` by an earlier
+        // reconciliation (or are part of the initial-state head).
+        if event.checkpoint <= floor_checkpoint {
+            continue;
+        }
+
+        // Advance to the first settlement at-or-past the event's
+        // ledger position.
+        while settlement_idx < settlements.len()
+            && (settlements[settlement_idx].0 < event.checkpoint
+                || (settlements[settlement_idx].0 == event.checkpoint
+                    && settlements[settlement_idx].1 < event.transaction_offset))
+        {
+            settlement_idx += 1;
+        }
+
+        if settlement_idx >= settlements.len() || settlements[settlement_idx].0 != event.checkpoint
+        {
+            // The framework guarantees a `settle_events` transaction
+            // for every checkpoint that emitted events on this stream;
+            // a missing settlement means the server's event index and
+            // transaction index have diverged.
+            return Err(LightClientError::UnexpectedObjectShape {
+                reason: "no settlement transaction covering buffered event",
+            });
+        }
+
+        let settlement_key = settlements[settlement_idx];
         let commitment = EventCommitment {
             checkpoint_seq: event.checkpoint,
             transaction_idx: event.transaction_offset,
             event_idx: event.event_index as u64,
             digest: event.event.digest(),
         };
-        match batches.last_mut() {
-            Some(batch) if batch.checkpoint_seq == event.checkpoint => {
-                batch.commitments.push(commitment);
+
+        match current_key {
+            Some(key) if key == settlement_key => {
+                batches
+                    .last_mut()
+                    .expect("current_key set ⇒ at least one batch exists")
+                    .commitments
+                    .push(commitment);
             }
-            _ => batches.push(EventBatch {
-                checkpoint_seq: event.checkpoint,
-                commitments: vec![commitment],
-            }),
+            _ => {
+                batches.push(EventBatch {
+                    checkpoint_seq: event.checkpoint,
+                    commitments: vec![commitment],
+                });
+                current_key = Some(settlement_key);
+            }
         }
     }
 
-    let new_head =
-        apply_stream_updates(state.local_head.clone(), &batches).map_err(LightClientError::from)?;
-
-    state.local_head = new_head;
-    for event in events {
-        state.pending.push_back(event);
-    }
-    Ok(())
-}
-
-/// Compare the locally-replayed MMR head against a freshly-fetched
-/// on-chain head and release the events whose folds the reconciliation
-/// covers.
-///
-/// Returns the events that should now be yielded to the consumer (in
-/// receipt order). Drains them from `state.pending` and advances
-/// `state.confirmed_through` to `chain_head.checkpoint_seq`. On
-/// divergence, returns [`LightClientError::MmrMismatch`] without
-/// mutating `state` — the caller should abort the stream rather than
-/// silently continue.
-pub(super) fn reconcile_local_head(
-    state: &mut StreamState,
-    chain_head: EventStreamHead,
-) -> Result<Vec<AuthenticatedEvent>, LightClientError> {
-    if state.local_head != chain_head {
-        return Err(LightClientError::MmrMismatch(Box::new(MmrMismatch {
-            checkpoint: chain_head.checkpoint_seq,
-            expected: chain_head,
-            actual: state.local_head.clone(),
-        })));
-    }
-
-    let confirmed_checkpoint = chain_head.checkpoint_seq;
-    let mut released = Vec::new();
-    while let Some(front) = state.pending.front() {
-        if front.checkpoint > confirmed_checkpoint {
-            break;
-        }
-        released.push(state.pending.pop_front().expect("just peeked"));
-    }
-    state.confirmed_through = confirmed_checkpoint;
-    Ok(released)
+    Ok(batches)
 }
 
 /// Extract the BCS-encoded [`EventStreamHead`] out of an on-chain
@@ -206,113 +341,240 @@ mod tests {
         }
     }
 
+    /// Build the chain-head state expected after folding `events`
+    /// bucketed against `settlements`. Mirrors what the test cluster
+    /// would produce on chain so reconciliation calls can be exercised
+    /// against an authoritative reference.
+    fn expected_chain_head(
+        events: &[AuthenticatedEvent],
+        settlements: &[(u64, u64)],
+    ) -> EventStreamHead {
+        let batches = bucket_events_by_settlement(events.iter(), settlements, 0).unwrap();
+        apply_stream_updates(EventStreamHead::default(), &batches).unwrap()
+    }
+
     fn u256_from_decimal(s: &str) -> U256 {
         s.parse().expect("decimal U256 literal must parse")
     }
 
-    /// One batch of events from a single checkpoint folds into a
-    /// single MMR peak. The locally-replayed head must match the
-    /// fold of the same `EventCommitment` sequence — this is the
-    /// invariant the streaming client relies on to make
-    /// reconciliation work, and it's enforced here against a vector
-    /// captured from upstream's `apply_stream_updates`.
+    /// `buffer_response_batch` only buffers — folding is deferred to
+    /// `fold_and_reconcile`. The local head must not move just from
+    /// receiving events.
     #[test]
-    fn process_response_batch_folds_single_checkpoint_into_one_peak() {
+    fn buffer_response_batch_defers_folding() {
         let mut state = StreamState::new(EventStreamHead::default(), 0);
+        let events = vec![sample_event(7, 0, 0), sample_event(7, 0, 1)];
+
+        buffer_response_batch(&mut state, events, Some(7));
+
+        assert_eq!(state.local_head, EventStreamHead::default());
+        assert_eq!(state.buffer.len(), 2);
+        assert_eq!(state.events_scanned_through, 7);
+    }
+
+    /// Events arriving without a watermark still bump
+    /// `events_scanned_through` to at least the last event's
+    /// checkpoint — otherwise reconciliation would never see those
+    /// checkpoints as "scanned" and skip them when fetching
+    /// settlements.
+    #[test]
+    fn buffer_response_batch_advances_scan_floor_from_events() {
+        let mut state = StreamState::new(EventStreamHead::default(), 0);
+        buffer_response_batch(&mut state, vec![sample_event(11, 0, 0)], None);
+        assert_eq!(state.events_scanned_through, 11);
+    }
+
+    /// `events_scanned_through` is monotonic — a smaller watermark
+    /// (e.g., a retry that re-emits earlier items) does not regress it.
+    #[test]
+    fn buffer_response_batch_does_not_regress_scan_floor() {
+        let mut state = StreamState::new(EventStreamHead::default(), 0);
+        state.events_scanned_through = 20;
+        buffer_response_batch(&mut state, vec![sample_event(5, 0, 0)], Some(5));
+        assert_eq!(state.events_scanned_through, 20);
+    }
+
+    /// Single settlement per checkpoint — the legacy case the previous
+    /// implementation also supported. All events at one checkpoint
+    /// fold into a single batch and the chain head matches.
+    #[test]
+    fn fold_and_reconcile_single_settlement_per_checkpoint() {
         let events = vec![
             sample_event(7, 0, 0),
             sample_event(7, 0, 1),
             sample_event(7, 1, 0),
         ];
+        let settlements = vec![(7u64, 2u64)];
 
-        process_response_batch(&mut state, events).unwrap();
+        let chain_head = expected_chain_head(&events, &settlements);
 
-        assert_eq!(state.local_head.checkpoint_seq, 7);
-        assert_eq!(state.local_head.num_events, 3);
-        assert_eq!(state.local_head.mmr.len(), 1);
-        assert_eq!(state.pending.len(), 3);
-    }
-
-    /// Two checkpoints worth of events fold as two distinct batches.
-    /// The MMR carries up to level 1 (slot 0 vacated, slot 1 filled),
-    /// matching the four-fold pin from `framework::test`.
-    #[test]
-    fn process_response_batch_groups_multiple_checkpoints_separately() {
         let mut state = StreamState::new(EventStreamHead::default(), 0);
-        let events = vec![sample_event(1, 0, 0), sample_event(2, 0, 0)];
+        buffer_response_batch(&mut state, events.clone(), Some(7));
 
-        process_response_batch(&mut state, events).unwrap();
+        let released = fold_and_reconcile(&mut state, &settlements, chain_head.clone(), 7).unwrap();
 
-        assert_eq!(state.local_head.checkpoint_seq, 2);
-        assert_eq!(state.local_head.num_events, 2);
-        assert_eq!(state.local_head.mmr.len(), 2);
-        assert_eq!(state.local_head.mmr[0], U256::ZERO);
-        assert!(state.local_head.mmr[1] != U256::ZERO);
-        assert_eq!(state.pending.len(), 2);
+        assert_eq!(released, events);
+        assert_eq!(state.local_head, chain_head);
+        assert_eq!(state.confirmed_through, 7);
+        assert!(state.buffer.is_empty());
     }
 
-    /// Folding zero events is a no-op on the local head.
+    /// Multiple settlements per checkpoint — the failure mode that
+    /// motivated this whole module. Three transactions in checkpoint
+    /// 10 settle in two `settle_events` calls, so events 0–1 fold as
+    /// one batch and event 2 folds as another. The chain head must
+    /// match only if both batches are folded separately.
     #[test]
-    fn process_response_batch_empty_input_is_identity() {
-        let initial = EventStreamHead {
-            mmr: vec![U256::ONE],
-            checkpoint_seq: 9,
+    fn fold_and_reconcile_multiple_settlements_per_checkpoint() {
+        let events = vec![
+            sample_event(10, 0, 0),
+            sample_event(10, 1, 0),
+            sample_event(10, 3, 0),
+        ];
+        // First two events settle at txn 2; the third settles at txn 4.
+        let settlements = vec![(10u64, 2u64), (10u64, 4u64)];
+
+        let chain_head = expected_chain_head(&events, &settlements);
+
+        let mut state = StreamState::new(EventStreamHead::default(), 0);
+        buffer_response_batch(&mut state, events.clone(), Some(10));
+
+        // Sanity-check that the two-batch fold differs from the
+        // (incorrect) single-batch fold the old code would have
+        // produced — this is the regression we're guarding against.
+        let single_batch = apply_stream_updates(
+            EventStreamHead::default(),
+            &[EventBatch {
+                checkpoint_seq: 10,
+                commitments: events
+                    .iter()
+                    .map(|e| EventCommitment {
+                        checkpoint_seq: e.checkpoint,
+                        transaction_idx: e.transaction_offset,
+                        event_idx: e.event_index as u64,
+                        digest: e.event.digest(),
+                    })
+                    .collect(),
+            }],
+        )
+        .unwrap();
+        assert_ne!(single_batch, chain_head);
+
+        let released =
+            fold_and_reconcile(&mut state, &settlements, chain_head.clone(), 10).unwrap();
+
+        assert_eq!(released, events);
+        assert_eq!(state.local_head, chain_head);
+        assert_eq!(state.confirmed_through, 10);
+    }
+
+    /// Reconciliation only consumes the buffer prefix at-or-below the
+    /// reconciliation point; events past it stay buffered for the next
+    /// round.
+    #[test]
+    fn fold_and_reconcile_keeps_unfolded_tail_buffered() {
+        let events = vec![
+            sample_event(5, 0, 0),
+            sample_event(5, 0, 1),
+            sample_event(9, 0, 0), // past the reconciliation point
+        ];
+        // Only the cp=5 settlement is in range; the cp=9 settlement
+        // hasn't been queried yet.
+        let settlements = vec![(5u64, 0u64)];
+
+        // Construct a chain head that represents folding only the cp=5
+        // events — this is what `prove_object_at_checkpoint(.., 5)`
+        // would return on chain.
+        let cp5_events: Vec<_> = events.iter().take(2).cloned().collect();
+        let chain_head_at_5 = expected_chain_head(&cp5_events, &settlements);
+
+        let mut state = StreamState::new(EventStreamHead::default(), 0);
+        buffer_response_batch(&mut state, events.clone(), Some(9));
+
+        let released =
+            fold_and_reconcile(&mut state, &settlements, chain_head_at_5.clone(), 5).unwrap();
+
+        assert_eq!(released, cp5_events);
+        assert_eq!(state.local_head, chain_head_at_5);
+        assert_eq!(state.confirmed_through, 5);
+        assert_eq!(state.buffer.len(), 1);
+        assert_eq!(state.buffer.front().unwrap().checkpoint, 9);
+    }
+
+    /// A chain head that doesn't match the locally-folded head returns
+    /// `MmrMismatch` and does NOT advance `confirmed_through` or drain
+    /// the buffer.
+    #[test]
+    fn fold_and_reconcile_rejects_divergence_without_mutating_observable_state() {
+        let events = vec![sample_event(3, 0, 0)];
+        let settlements = vec![(3u64, 0u64)];
+        let bogus = EventStreamHead {
+            mmr: vec![u256_from_decimal("999")],
+            checkpoint_seq: 3,
             num_events: 1,
         };
-        let mut state = StreamState::new(initial.clone(), 9);
-        process_response_batch(&mut state, vec![]).unwrap();
-        assert_eq!(state.local_head, initial);
-        assert!(state.pending.is_empty());
-    }
 
-    /// Reconciling against a matching chain head releases every
-    /// pending event up to (and including) the chain head's
-    /// checkpoint, and advances `confirmed_through`.
-    #[test]
-    fn reconcile_local_head_releases_matching_events() {
         let mut state = StreamState::new(EventStreamHead::default(), 0);
-        process_response_batch(
-            &mut state,
-            vec![
-                sample_event(1, 0, 0),
-                sample_event(2, 0, 0),
-                sample_event(3, 0, 0),
-            ],
-        )
-        .unwrap();
+        buffer_response_batch(&mut state, events.clone(), Some(3));
+        let pre_local_head = state.local_head.clone();
+        let pre_buffer_len = state.buffer.len();
+        let pre_confirmed = state.confirmed_through;
 
-        // Construct a chain head that matches the post-batch-2 state
-        // by folding only the first two events.
-        let mut partial = StreamState::new(EventStreamHead::default(), 0);
-        process_response_batch(
-            &mut partial,
-            vec![sample_event(1, 0, 0), sample_event(2, 0, 0)],
-        )
-        .unwrap();
-        let chain_head_at_2 = partial.local_head.clone();
-
-        // Reconciliation against the partial head should fail because
-        // our local head has *3* events folded in.
-        let err = reconcile_local_head(&mut state, chain_head_at_2.clone()).unwrap_err();
+        let err = fold_and_reconcile(&mut state, &settlements, bogus.clone(), 3).unwrap_err();
         assert!(matches!(err, LightClientError::MmrMismatch(_)));
 
-        // Reset and try with the full head — that should match and
-        // release all three.
+        assert_eq!(state.local_head, pre_local_head);
+        assert_eq!(state.buffer.len(), pre_buffer_len);
+        assert_eq!(state.confirmed_through, pre_confirmed);
+    }
+
+    /// Calling `fold_and_reconcile` with no settlements is a hard
+    /// error — the caller is contracted to only invoke it after
+    /// `ListTransactions` has surfaced at least one settlement in the
+    /// scan range.
+    #[test]
+    fn fold_and_reconcile_rejects_empty_settlements() {
         let mut state = StreamState::new(EventStreamHead::default(), 0);
-        process_response_batch(
-            &mut state,
-            vec![
-                sample_event(1, 0, 0),
-                sample_event(2, 0, 0),
-                sample_event(3, 0, 0),
-            ],
-        )
-        .unwrap();
-        let chain_head_at_3 = state.local_head.clone();
-        let released = reconcile_local_head(&mut state, chain_head_at_3).unwrap();
-        assert_eq!(released.len(), 3);
-        assert_eq!(state.confirmed_through, 3);
-        assert!(state.pending.is_empty());
+        let err = fold_and_reconcile(&mut state, &[], EventStreamHead::default(), 0).unwrap_err();
+        assert!(matches!(
+            err,
+            LightClientError::UnexpectedObjectShape { .. }
+        ));
+    }
+
+    /// The reconciliation checkpoint must match the last settlement's
+    /// checkpoint — otherwise the local fold would terminate at a
+    /// different head than the on-chain proof attests to.
+    #[test]
+    fn fold_and_reconcile_rejects_misaligned_reconcile_checkpoint() {
+        let settlements = vec![(5u64, 0u64)];
+        let mut state = StreamState::new(EventStreamHead::default(), 0);
+        let err = fold_and_reconcile(&mut state, &settlements, EventStreamHead::default(), 7)
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            LightClientError::UnexpectedObjectShape { .. }
+        ));
+    }
+
+    /// A buffered event whose checkpoint has no settlement in range is
+    /// a server-side index inconsistency — surface it as
+    /// `UnexpectedObjectShape` rather than fold silently into the
+    /// wrong bucket.
+    #[test]
+    fn fold_and_reconcile_rejects_event_without_matching_settlement() {
+        // Event at cp=5 but settlement only exists at cp=7.
+        let events = vec![sample_event(5, 0, 0)];
+        let settlements = vec![(7u64, 0u64)];
+        let mut state = StreamState::new(EventStreamHead::default(), 0);
+        buffer_response_batch(&mut state, events, Some(7));
+
+        let err = fold_and_reconcile(&mut state, &settlements, EventStreamHead::default(), 7)
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            LightClientError::UnexpectedObjectShape { .. }
+        ));
     }
 
     /// `extract_event_stream_head` skips the dynamic-field UID and
@@ -398,37 +660,5 @@ mod tests {
             err,
             LightClientError::UnexpectedObjectShape { .. }
         ));
-    }
-
-    /// A `chain_head` that doesn't match the local head returns
-    /// `MmrMismatch` and leaves `state` untouched so the caller can
-    /// abort cleanly.
-    #[test]
-    fn reconcile_local_head_rejects_divergence_without_mutating_state() {
-        let mut state = StreamState::new(EventStreamHead::default(), 0);
-        process_response_batch(&mut state, vec![sample_event(1, 0, 0)]).unwrap();
-        let pre = state.local_head.clone();
-        let pre_pending = state.pending.len();
-        let pre_confirmed = state.confirmed_through;
-
-        let bogus_chain_head = EventStreamHead {
-            mmr: vec![u256_from_decimal("999")],
-            checkpoint_seq: 1,
-            num_events: 1,
-        };
-        let err = reconcile_local_head(&mut state, bogus_chain_head.clone()).unwrap_err();
-
-        match err {
-            LightClientError::MmrMismatch(boxed) => {
-                assert_eq!(boxed.checkpoint, 1);
-                assert_eq!(boxed.expected, bogus_chain_head);
-                assert_eq!(boxed.actual, pre);
-            }
-            other => panic!("expected MmrMismatch, got {other:?}"),
-        }
-
-        assert_eq!(state.local_head, pre);
-        assert_eq!(state.pending.len(), pre_pending);
-        assert_eq!(state.confirmed_through, pre_confirmed);
     }
 }


### PR DESCRIPTION
Previously, the authenticated events streaming client assumed at most one MMR fold per checkpoint and grouped received events into a single `EventBatch` keyed on `checkpoint_seq`. The framework actually runs one `settle_events` per consensus commit per stream, so a checkpoint that aggregates multiple commits produces multiple folds at the same `checkpoint_seq`. With this commit, the streaming client now buffers received events and partitions them by settlement boundary before folding into the local MMR, so reconciliation against the on-chain `EventStreamHead` matches even for multi-commit checkpoints.

`StreamState` now buffers events in a `VecDeque<AuthenticatedEvent>` rather than folding them on receipt, and tracks
`events_scanned_through` from each `Watermark.checkpoint_hi` observed across both standalone and per-item watermarks.

Settlement boundaries are fetched at reconciliation time via `ListTransactions(affected_object = event_stream_head_object_id)` — the head is mutated once per `settle_events`, so this filter returns exactly the per-stream settlement transactions in
`(confirmed_through, events_scanned_through]`. Each buffered event maps to the first settlement with `(cp == event.cp, tx_offset >= event.tx_offset)`; events sharing a settlement key form a single `EventBatch`. The chain head is then proven at the last settlement's checkpoint — always an `Inclusion` result by construction — and the locally-folded head is compared byte-for-byte against it. On match, the folded events are released to the consumer and `confirmed_through` advances to the reconciliation checkpoint. Events past it stay buffered for the next round.

Also add tests for: deferred buffering, multi-settlement-per-checkpoint folding (with a regression assertion that the new partitioning differs from the old single-batch fold), settlement-disaligned reconciliation checkpoints, and missing-settlement / empty-settlement error paths.