### PR TITLE
proto-build: split into a library and binary

### DIFF
--- a/crates/proto-build/src/codegen/accessors.rs
+++ b/crates/proto-build/src/codegen/accessors.rs
@@ -11,7 +11,7 @@ use crate::message_graph::Field;
 use crate::message_graph::Message;
 use crate::message_graph::OneofField;
 
-pub(crate) fn generate_accessors(context: &Context, out_dir: &Path) {
+pub fn generate_accessors(context: &Context, out_dir: &Path) {
     for package in context.graph().packages.iter() {
         let mut stream = TokenStream::new();
 

--- a/crates/proto-build/src/generate_fields.rs
+++ b/crates/proto-build/src/generate_fields.rs
@@ -9,7 +9,7 @@ use prost_types::FileDescriptorSet;
 use prost_types::field_descriptor_proto::Type;
 use quote::quote;
 
-pub(crate) fn generate_field_info(packages: &HashMap<String, FileDescriptorSet>, out_dir: &Path) {
+pub fn generate_field_info(packages: &HashMap<String, FileDescriptorSet>, out_dir: &Path) {
     for (package, fds) in packages {
         if package.contains("google") {
             continue;

--- a/crates/proto-build/src/lib.rs
+++ b/crates/proto-build/src/lib.rs
@@ -1,0 +1,13 @@
+pub use pbjson_build;
+pub use prost;
+pub use prost_types;
+pub use protox;
+pub use tonic_prost_build;
+
+pub mod codegen;
+pub mod context;
+pub mod generate_fields;
+pub mod message_graph;
+
+mod comments;
+mod ident;

--- a/crates/proto-build/src/main.rs
+++ b/crates/proto-build/src/main.rs
@@ -3,14 +3,10 @@ use protox::prost::Message as _;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use crate::message_graph::DescriptorGraph;
-
-mod codegen;
-mod comments;
-mod context;
-mod generate_fields;
-mod ident;
-mod message_graph;
+use proto_build::codegen;
+use proto_build::context;
+use proto_build::generate_fields;
+use proto_build::message_graph::DescriptorGraph;
 
 fn main() {
     let root_dir = PathBuf::from(std::env!("CARGO_MANIFEST_DIR"));

--- a/crates/proto-build/src/message_graph.rs
+++ b/crates/proto-build/src/message_graph.rs
@@ -37,7 +37,7 @@ pub struct DescriptorGraph {
 }
 
 impl DescriptorGraph {
-    pub(crate) fn new<'a>(files: impl Iterator<Item = &'a FileDescriptorProto>) -> DescriptorGraph {
+    pub fn new<'a>(files: impl Iterator<Item = &'a FileDescriptorProto>) -> DescriptorGraph {
         let mut graph = DescriptorGraph {
             index: BTreeMap::new(),
             graph: Graph::new(),


### PR DESCRIPTION
Previously, `proto-build` was a binary-only crate with all codegen modules and the driver logic living in `main.rs`. With this commit, the codegen modules move into a new library target so they can be reused by other crates, while `main.rs` retains the driver entry point and reaches the modules through the `proto_build` lib.

The library also re-exports the upstream codegen crates `pbjson_build`, `prost`, `prost_types`, `protox`, and `tonic_prost_build`, so downstream consumers can drive codegen without depending on them directly.

`DescriptorGraph::new`, `generate_accessors`, and `generate_field_info` are now `pub` rather than `pub(crate)` so the binary can call them across the library boundary.