### PR TITLE
fix: remove erroneous apostrophe in README goals list

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains a collection of libraries for integrating with the Sui 
 
 A few of the project's high-level goals are as follows:
 
-* **Be modular** - user's should only need to pay the cost (in terms of dependencies/compilation time) for the features that they use.
+* **Be modular** - users should only need to pay the cost (in terms of dependencies/compilation time) for the features that they use.
 * **Be light** - strive to have a minimal dependency footprint.
 * **Support developers** - provide all needed types, abstractions and APIs to enable developers to build robust applications on Sui.
 * **Support wasm** - where possible, libraries should be usable in wasm environments.


### PR DESCRIPTION
### What
Remove the stray apostrophe in "user's" → "users" in the README goals list.

### Why
"user's" is possessive; the intended meaning is the plural "users". Plain typo fix.

Small, scoped fix from kcolbchain contrib-bot.