### PR TITLE
docs: add sui-graphql to crates list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ In an effort to be modular, functionality is split between a number of crates.
     [![sui-transaction-builder on crates.io](https://img.shields.io/crates/v/sui-transaction-builder)](https://crates.io/crates/sui-transaction-builder)
     [![Documentation (latest release)](https://img.shields.io/badge/docs-latest-brightgreen)](https://docs.rs/sui-transaction-builder)
     [![Documentation (master)](https://img.shields.io/badge/docs-master-59f)](https://mystenlabs.github.io/sui-rust-sdk/sui_transaction_builder/)
+* [`sui-graphql`](crates/sui-graphql)
+    [![sui-graphql on crates.io](https://img.shields.io/crates/v/sui-graphql)](https://crates.io/crates/sui-graphql)
+    [![Documentation (latest release)](https://img.shields.io/badge/docs-latest-brightgreen)](https://docs.rs/sui-graphql)
+    [![Documentation (master)](https://img.shields.io/badge/docs-master-59f)](https://mystenlabs.github.io/sui-rust-sdk/sui_graphql/)
 
 ## License
 


### PR DESCRIPTION
Adds the `sui-graphql` crate to the Crates section of the README, since it has public docs like the other crates.

Follows the existing format with three badges: crates.io version, latest-release docs (docs.rs), and master docs (GitHub Pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)