### PR TITLE
sui-crypto: add support for the legacy Base64 keystore key format

### DIFF
--- a/crates/sui-crypto/Cargo.toml
+++ b/crates/sui-crypto/Cargo.toml
@@ -33,7 +33,6 @@ zklogin = [
     "dep:ark-groth16",
     "dep:ark-snark",
     "dep:ark-std",
-    "dep:base64ct",
     "dep:bnum",
     "dep:itertools",
     "dep:serde",
@@ -61,6 +60,9 @@ bech32 = ["dep:bech32"]
 [dependencies]
 signature = "2.2"
 sui-sdk-types = { version = "0.3.0", path = "../sui-sdk-types", default-features = false, features = ["hash", "serde"] }
+# Already a transitive dependency via sui-sdk-types, so this adds nothing to
+# the dependency tree. Used for the legacy Base64 keystore key format.
+base64ct = { version = "1.8.0", features = ["alloc"] }
 
 # RNG support
 rand_core = { version = "0.6.4", optional = true }
@@ -83,7 +85,6 @@ ark-ff = { version = "0.4.2", features = ["asm"], optional = true }
 ark-groth16 = { version = "0.4.0", default-features = false, optional = true }
 ark-snark = { version = "0.4.0", optional = true }
 ark-std = { version = "0.4.0", optional = true }
-base64ct = { version = "1.8.0", features = ["alloc"], optional = true }
 bnum = { version = "0.13.0", optional = true }
 itertools = { version = "0.14.0", optional = true }
 serde = { version = "1.0.228", optional = true }

--- a/crates/sui-crypto/src/ed25519.rs
+++ b/crates/sui-crypto/src/ed25519.rs
@@ -108,6 +108,24 @@ impl Ed25519PrivateKey {
         Self(private_key)
     }
 
+    /// Build a key from the scheme flag and key bytes of a decoded
+    /// `flag || private_key` payload.
+    fn from_flagged_key_bytes(
+        scheme: SignatureScheme,
+        key: Vec<u8>,
+    ) -> Result<Self, SignatureError> {
+        if scheme != SignatureScheme::Ed25519 {
+            return Err(SignatureError::from_source(format!(
+                "private key scheme flag is `{}`, expected `ed25519`",
+                scheme.name(),
+            )));
+        }
+        let bytes: [u8; Self::LENGTH] = key.try_into().map_err(|_: Vec<u8>| {
+            SignatureError::from_source("private key has invalid length for ed25519")
+        })?;
+        Ok(Self::new(bytes))
+    }
+
     #[cfg(feature = "bech32")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "bech32")))]
     /// Decode a Bech32 `suiprivkey` string produced by the Sui CLI.
@@ -117,16 +135,7 @@ impl Ed25519PrivateKey {
     /// Ed25519, or has the wrong number of key bytes.
     pub fn from_suiprivkey(s: &str) -> Result<Self, SignatureError> {
         let (scheme, key) = crate::suipriv::decode(s)?;
-        if scheme != SignatureScheme::Ed25519 {
-            return Err(SignatureError::from_source(format!(
-                "suipriv scheme flag is `{}`, expected `ed25519`",
-                scheme.name(),
-            )));
-        }
-        let bytes: [u8; Self::LENGTH] = key.try_into().map_err(|_: Vec<u8>| {
-            SignatureError::from_source("suipriv key has invalid length for ed25519")
-        })?;
-        Ok(Self::new(bytes))
+        Self::from_flagged_key_bytes(scheme, key)
     }
 
     #[cfg(feature = "bech32")]
@@ -134,6 +143,23 @@ impl Ed25519PrivateKey {
     /// Encode this private key as a Bech32 `suiprivkey` string.
     pub fn to_suiprivkey(&self) -> Result<String, SignatureError> {
         crate::suipriv::encode(SignatureScheme::Ed25519, self.0.to_bytes().as_slice())
+    }
+
+    /// Decode a Base64 `flag || private_key` string, the legacy keystore
+    /// format used for entries of the Sui CLI's `sui.keystore` file.
+    ///
+    /// Returns an error if the string is not valid Base64, has a flag byte
+    /// that is not Ed25519, or has the wrong number of key bytes.
+    pub fn from_base64(s: &str) -> Result<Self, SignatureError> {
+        let (scheme, key) = crate::suipriv::decode_base64(s)?;
+        Self::from_flagged_key_bytes(scheme, key)
+    }
+
+    /// Encode this private key as a Base64 `flag || private_key` string, the
+    /// legacy keystore format used for entries of the Sui CLI's
+    /// `sui.keystore` file.
+    pub fn to_base64(&self) -> String {
+        crate::suipriv::encode_base64(SignatureScheme::Ed25519, self.0.to_bytes().as_slice())
     }
 }
 

--- a/crates/sui-crypto/src/lib.rs
+++ b/crates/sui-crypto/src/lib.rs
@@ -49,10 +49,7 @@ pub mod zklogin;
 )]
 pub mod simple;
 
-#[cfg(all(
-    feature = "bech32",
-    any(feature = "ed25519", feature = "secp256r1", feature = "secp256k1")
-))]
+#[cfg(any(feature = "ed25519", feature = "secp256r1", feature = "secp256k1"))]
 mod suipriv;
 
 #[cfg(any(

--- a/crates/sui-crypto/src/secp256k1.rs
+++ b/crates/sui-crypto/src/secp256k1.rs
@@ -111,6 +111,24 @@ impl Secp256k1PrivateKey {
         Self(private_key)
     }
 
+    /// Build a key from the scheme flag and key bytes of a decoded
+    /// `flag || private_key` payload.
+    fn from_flagged_key_bytes(
+        scheme: SignatureScheme,
+        key: Vec<u8>,
+    ) -> Result<Self, SignatureError> {
+        if scheme != SignatureScheme::Secp256k1 {
+            return Err(SignatureError::from_source(format!(
+                "private key scheme flag is `{}`, expected `secp256k1`",
+                scheme.name(),
+            )));
+        }
+        let bytes: [u8; Self::LENGTH] = key.try_into().map_err(|_: Vec<u8>| {
+            SignatureError::from_source("private key has invalid length for secp256k1")
+        })?;
+        Self::new(bytes)
+    }
+
     #[cfg(feature = "bech32")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "bech32")))]
     /// Decode a Bech32 `suiprivkey` string produced by the Sui CLI.
@@ -121,16 +139,7 @@ impl Secp256k1PrivateKey {
     /// not form a valid secp256k1 scalar.
     pub fn from_suiprivkey(s: &str) -> Result<Self, SignatureError> {
         let (scheme, key) = crate::suipriv::decode(s)?;
-        if scheme != SignatureScheme::Secp256k1 {
-            return Err(SignatureError::from_source(format!(
-                "suipriv scheme flag is `{}`, expected `secp256k1`",
-                scheme.name(),
-            )));
-        }
-        let bytes: [u8; Self::LENGTH] = key.try_into().map_err(|_: Vec<u8>| {
-            SignatureError::from_source("suipriv key has invalid length for secp256k1")
-        })?;
-        Self::new(bytes)
+        Self::from_flagged_key_bytes(scheme, key)
     }
 
     #[cfg(feature = "bech32")]
@@ -139,6 +148,25 @@ impl Secp256k1PrivateKey {
     pub fn to_suiprivkey(&self) -> Result<String, SignatureError> {
         let bytes = self.0.to_bytes();
         crate::suipriv::encode(SignatureScheme::Secp256k1, &bytes)
+    }
+
+    /// Decode a Base64 `flag || private_key` string, the legacy keystore
+    /// format used for entries of the Sui CLI's `sui.keystore` file.
+    ///
+    /// Returns an error if the string is not valid Base64, has a flag byte
+    /// that is not Secp256k1, has the wrong number of key bytes, or carries
+    /// bytes that do not form a valid secp256k1 scalar.
+    pub fn from_base64(s: &str) -> Result<Self, SignatureError> {
+        let (scheme, key) = crate::suipriv::decode_base64(s)?;
+        Self::from_flagged_key_bytes(scheme, key)
+    }
+
+    /// Encode this private key as a Base64 `flag || private_key` string, the
+    /// legacy keystore format used for entries of the Sui CLI's
+    /// `sui.keystore` file.
+    pub fn to_base64(&self) -> String {
+        let bytes = self.0.to_bytes();
+        crate::suipriv::encode_base64(SignatureScheme::Secp256k1, &bytes)
     }
 }
 

--- a/crates/sui-crypto/src/secp256r1.rs
+++ b/crates/sui-crypto/src/secp256r1.rs
@@ -111,25 +111,40 @@ impl Secp256r1PrivateKey {
         Self(private_key)
     }
 
+    /// Build a key from the scheme flag and key bytes of a decoded
+    /// `flag || private_key` payload.
+    ///
+    /// Unlike [`Self::new`] this does not panic on key bytes that do not
+    /// form a valid secp256r1 scalar, since the payload is untrusted input.
+    fn from_flagged_key_bytes(
+        scheme: SignatureScheme,
+        key: Vec<u8>,
+    ) -> Result<Self, SignatureError> {
+        if scheme != SignatureScheme::Secp256r1 {
+            return Err(SignatureError::from_source(format!(
+                "private key scheme flag is `{}`, expected `secp256r1`",
+                scheme.name(),
+            )));
+        }
+        let bytes: [u8; Self::LENGTH] = key.try_into().map_err(|_: Vec<u8>| {
+            SignatureError::from_source("private key has invalid length for secp256r1")
+        })?;
+        SigningKey::from_bytes(&bytes.into())
+            .map(Self)
+            .map_err(SignatureError::from_source)
+    }
+
     #[cfg(feature = "bech32")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "bech32")))]
     /// Decode a Bech32 `suiprivkey` string produced by the Sui CLI.
     ///
     /// Returns an error if the string does not have the `suiprivkey` HRP, has
     /// an invalid Bech32 (BIP-173) checksum, has a flag byte that is not
-    /// Secp256r1, or has the wrong number of key bytes.
+    /// Secp256r1, has the wrong number of key bytes, or carries bytes that do
+    /// not form a valid secp256r1 scalar.
     pub fn from_suiprivkey(s: &str) -> Result<Self, SignatureError> {
         let (scheme, key) = crate::suipriv::decode(s)?;
-        if scheme != SignatureScheme::Secp256r1 {
-            return Err(SignatureError::from_source(format!(
-                "suipriv scheme flag is `{}`, expected `secp256r1`",
-                scheme.name(),
-            )));
-        }
-        let bytes: [u8; Self::LENGTH] = key.try_into().map_err(|_: Vec<u8>| {
-            SignatureError::from_source("suipriv key has invalid length for secp256r1")
-        })?;
-        Ok(Self::new(bytes))
+        Self::from_flagged_key_bytes(scheme, key)
     }
 
     #[cfg(feature = "bech32")]
@@ -138,6 +153,25 @@ impl Secp256r1PrivateKey {
     pub fn to_suiprivkey(&self) -> Result<String, SignatureError> {
         let bytes = self.0.to_bytes();
         crate::suipriv::encode(SignatureScheme::Secp256r1, &bytes)
+    }
+
+    /// Decode a Base64 `flag || private_key` string, the legacy keystore
+    /// format used for entries of the Sui CLI's `sui.keystore` file.
+    ///
+    /// Returns an error if the string is not valid Base64, has a flag byte
+    /// that is not Secp256r1, has the wrong number of key bytes, or carries
+    /// bytes that do not form a valid secp256r1 scalar.
+    pub fn from_base64(s: &str) -> Result<Self, SignatureError> {
+        let (scheme, key) = crate::suipriv::decode_base64(s)?;
+        Self::from_flagged_key_bytes(scheme, key)
+    }
+
+    /// Encode this private key as a Base64 `flag || private_key` string, the
+    /// legacy keystore format used for entries of the Sui CLI's
+    /// `sui.keystore` file.
+    pub fn to_base64(&self) -> String {
+        let bytes = self.0.to_bytes();
+        crate::suipriv::encode_base64(SignatureScheme::Secp256r1, &bytes)
     }
 }
 

--- a/crates/sui-crypto/src/simple.rs
+++ b/crates/sui-crypto/src/simple.rs
@@ -221,22 +221,22 @@ mod keypair {
             }
         }
 
-        #[cfg(feature = "bech32")]
-        #[cfg_attr(doc_cfg, doc(cfg(feature = "bech32")))]
-        /// Decode a Bech32 `suiprivkey` string produced by the Sui CLI.
+        /// Build a keypair from the scheme flag and key bytes of a decoded
+        /// `flag || private_key` payload.
         ///
-        /// The leading flag byte selects the scheme. Only the simple schemes
-        /// (Ed25519, Secp256k1, Secp256r1) are accepted, matching the
-        /// upstream `sui-types` parser.
-        pub fn from_suiprivkey(s: &str) -> Result<Self, SignatureError> {
-            let (scheme, key) = crate::suipriv::decode(s)?;
+        /// Only the simple schemes (Ed25519, Secp256k1, Secp256r1) are
+        /// accepted, matching the upstream `sui-types` parser.
+        fn from_flagged_key_bytes(
+            scheme: SignatureScheme,
+            key: Vec<u8>,
+        ) -> Result<Self, SignatureError> {
             let inner = match scheme {
                 #[cfg(feature = "ed25519")]
                 SignatureScheme::Ed25519 => {
                     let bytes: [u8; crate::ed25519::Ed25519PrivateKey::LENGTH] =
                         key.try_into().map_err(|_: Vec<u8>| {
                             SignatureError::from_source(
-                                "suipriv key has invalid length for ed25519",
+                                "private key has invalid length for ed25519",
                             )
                         })?;
                     InnerKeypair::Ed25519(crate::ed25519::Ed25519PrivateKey::new(bytes))
@@ -246,7 +246,7 @@ mod keypair {
                     let bytes: [u8; crate::secp256k1::Secp256k1PrivateKey::LENGTH] =
                         key.try_into().map_err(|_: Vec<u8>| {
                             SignatureError::from_source(
-                                "suipriv key has invalid length for secp256k1",
+                                "private key has invalid length for secp256k1",
                             )
                         })?;
                     InnerKeypair::Secp256k1(crate::secp256k1::Secp256k1PrivateKey::new(bytes)?)
@@ -256,19 +256,31 @@ mod keypair {
                     let bytes: [u8; crate::secp256r1::Secp256r1PrivateKey::LENGTH] =
                         key.try_into().map_err(|_: Vec<u8>| {
                             SignatureError::from_source(
-                                "suipriv key has invalid length for secp256r1",
+                                "private key has invalid length for secp256r1",
                             )
                         })?;
                     InnerKeypair::Secp256r1(crate::secp256r1::Secp256r1PrivateKey::new(bytes))
                 }
                 other => {
                     return Err(SignatureError::from_source(format!(
-                        "unsupported scheme `{}` in suipriv encoding",
+                        "unsupported scheme `{}` in private key encoding",
                         other.name(),
                     )));
                 }
             };
             Ok(Self { inner })
+        }
+
+        #[cfg(feature = "bech32")]
+        #[cfg_attr(doc_cfg, doc(cfg(feature = "bech32")))]
+        /// Decode a Bech32 `suiprivkey` string produced by the Sui CLI.
+        ///
+        /// The leading flag byte selects the scheme. Only the simple schemes
+        /// (Ed25519, Secp256k1, Secp256r1) are accepted, matching the
+        /// upstream `sui-types` parser.
+        pub fn from_suiprivkey(s: &str) -> Result<Self, SignatureError> {
+            let (scheme, key) = crate::suipriv::decode(s)?;
+            Self::from_flagged_key_bytes(scheme, key)
         }
 
         #[cfg(feature = "bech32")]
@@ -282,6 +294,31 @@ mod keypair {
                 InnerKeypair::Secp256k1(private_key) => private_key.to_suiprivkey(),
                 #[cfg(feature = "secp256r1")]
                 InnerKeypair::Secp256r1(private_key) => private_key.to_suiprivkey(),
+            }
+        }
+
+        /// Decode a Base64 `flag || private_key` string, the legacy keystore
+        /// format used for entries of the Sui CLI's `sui.keystore` file.
+        ///
+        /// The leading flag byte selects the scheme. Only the simple schemes
+        /// (Ed25519, Secp256k1, Secp256r1) are accepted, matching the
+        /// upstream `sui-types` parser.
+        pub fn from_base64(s: &str) -> Result<Self, SignatureError> {
+            let (scheme, key) = crate::suipriv::decode_base64(s)?;
+            Self::from_flagged_key_bytes(scheme, key)
+        }
+
+        /// Encode this private key as a Base64 `flag || private_key` string,
+        /// the legacy keystore format used for entries of the Sui CLI's
+        /// `sui.keystore` file.
+        pub fn to_base64(&self) -> String {
+            match &self.inner {
+                #[cfg(feature = "ed25519")]
+                InnerKeypair::Ed25519(private_key) => private_key.to_base64(),
+                #[cfg(feature = "secp256k1")]
+                InnerKeypair::Secp256k1(private_key) => private_key.to_base64(),
+                #[cfg(feature = "secp256r1")]
+                InnerKeypair::Secp256r1(private_key) => private_key.to_base64(),
             }
         }
     }
@@ -375,6 +412,24 @@ mod keypair {
                 #[cfg(feature = "secp256r1")]
                 InnerVerifyingKey::Secp256r1(verifying_key) => {
                     MultisigMemberPublicKey::Secp256r1(verifying_key.public_key())
+                }
+            }
+        }
+
+        /// Derive the `Address` that corresponds to this public key.
+        pub fn derive_address(&self) -> sui_sdk_types::Address {
+            match &self.inner {
+                #[cfg(feature = "ed25519")]
+                InnerVerifyingKey::Ed25519(verifying_key) => {
+                    verifying_key.public_key().derive_address()
+                }
+                #[cfg(feature = "secp256k1")]
+                InnerVerifyingKey::Secp256k1(verifying_key) => {
+                    verifying_key.public_key().derive_address()
+                }
+                #[cfg(feature = "secp256r1")]
+                InnerVerifyingKey::Secp256r1(verifying_key) => {
+                    verifying_key.public_key().derive_address()
                 }
             }
         }
@@ -703,6 +758,27 @@ mod test {
         assert_eq!(pem, from_pem.to_pem().unwrap());
     }
 
+    #[proptest]
+    fn simple_verifying_key_derives_matching_address(
+        ed25519: Ed25519PrivateKey,
+        secp256k1: Secp256k1PrivateKey,
+        secp256r1: Secp256r1PrivateKey,
+    ) {
+        // SimpleVerifiyingKey::derive_address must agree with the address
+        // derived from the scheme-specific public key.
+        let expected = ed25519.public_key().derive_address();
+        let keypair = SimpleKeypair::from(ed25519);
+        assert_eq!(keypair.verifying_key().derive_address(), expected);
+
+        let expected = secp256k1.public_key().derive_address();
+        let keypair = SimpleKeypair::from(secp256k1);
+        assert_eq!(keypair.verifying_key().derive_address(), expected);
+
+        let expected = secp256r1.public_key().derive_address();
+        let keypair = SimpleKeypair::from(secp256r1);
+        assert_eq!(keypair.verifying_key().derive_address(), expected);
+    }
+
     // Round-trip and rejection tests for the suiprivkey Bech32 format.
     //
     // These mirror the format produced by the Sui CLI and the upstream
@@ -809,6 +885,105 @@ mod test {
 
             SimpleKeypair::from_suiprivkey(&bech32m).unwrap_err();
             Ed25519PrivateKey::from_suiprivkey(&bech32m).unwrap_err();
+        }
+    }
+
+    // Round-trip and rejection tests for the legacy Base64 keystore format.
+    //
+    // The payload is the same `flag || private_key` bytes as the Bech32
+    // `suiprivkey` format, encoded as plain Base64 instead. This is the
+    // encoding used for entries of the Sui CLI's `sui.keystore` file.
+    mod base64 {
+        use super::*;
+        use sui_sdk_types::SignatureScheme;
+
+        #[cfg(target_arch = "wasm32")]
+        use wasm_bindgen_test::wasm_bindgen_test as test;
+
+        // The same payload as the bech32 module's upstream Ed25519 vector
+        // (`Ed25519KeyPair::generate(&mut StdRng::from_seed([0; 32]))`),
+        // Base64-encoded: 0x00 flag byte followed by the 32 private key
+        // bytes.
+        const UPSTREAM_ED25519_BASE64: &str = "AJv0mmoHVflTgR/OEl8mg9UEKcO7SeB0FH4AiaUurhVf";
+
+        #[proptest]
+        fn ed25519_round_trip(signer: Ed25519PrivateKey) {
+            let encoded = signer.to_base64();
+            let decoded = Ed25519PrivateKey::from_base64(&encoded).unwrap();
+            assert_eq!(decoded.public_key(), signer.public_key());
+
+            // SimpleKeypair dispatch agrees.
+            let keypair = SimpleKeypair::from_base64(&encoded).unwrap();
+            assert_eq!(keypair.scheme(), signer.scheme());
+            assert_eq!(encoded, keypair.to_base64());
+        }
+
+        #[proptest]
+        fn secp256k1_round_trip(signer: Secp256k1PrivateKey) {
+            let encoded = signer.to_base64();
+            let decoded = Secp256k1PrivateKey::from_base64(&encoded).unwrap();
+            assert_eq!(decoded.public_key(), signer.public_key());
+
+            let keypair = SimpleKeypair::from_base64(&encoded).unwrap();
+            assert_eq!(keypair.scheme(), signer.scheme());
+            assert_eq!(encoded, keypair.to_base64());
+        }
+
+        #[proptest]
+        fn secp256r1_round_trip(signer: Secp256r1PrivateKey) {
+            let encoded = signer.to_base64();
+            let decoded = Secp256r1PrivateKey::from_base64(&encoded).unwrap();
+            assert_eq!(decoded.public_key(), signer.public_key());
+
+            let keypair = SimpleKeypair::from_base64(&encoded).unwrap();
+            assert_eq!(keypair.scheme(), signer.scheme());
+            assert_eq!(encoded, keypair.to_base64());
+        }
+
+        #[test]
+        fn upstream_ed25519_vector_round_trips() {
+            let keypair = SimpleKeypair::from_base64(UPSTREAM_ED25519_BASE64).unwrap();
+            assert_eq!(keypair.scheme(), SignatureScheme::Ed25519);
+            assert_eq!(keypair.to_base64(), UPSTREAM_ED25519_BASE64);
+
+            // Per-scheme decoder accepts it too.
+            Ed25519PrivateKey::from_base64(UPSTREAM_ED25519_BASE64).unwrap();
+            // Wrong-scheme per-scheme decoders reject it.
+            Secp256k1PrivateKey::from_base64(UPSTREAM_ED25519_BASE64).unwrap_err();
+            Secp256r1PrivateKey::from_base64(UPSTREAM_ED25519_BASE64).unwrap_err();
+        }
+
+        #[cfg(feature = "bech32")]
+        #[test]
+        fn agrees_with_suiprivkey_encoding() {
+            // Both encodings carry the same payload, so converting between
+            // them must be lossless.
+            let keypair = SimpleKeypair::from_base64(UPSTREAM_ED25519_BASE64).unwrap();
+            let suiprivkey = keypair.to_suiprivkey().unwrap();
+            let round_tripped = SimpleKeypair::from_suiprivkey(&suiprivkey).unwrap();
+            assert_eq!(round_tripped.to_base64(), UPSTREAM_ED25519_BASE64);
+        }
+
+        #[test]
+        fn rejects_invalid_input() {
+            // Not Base64 at all.
+            SimpleKeypair::from_base64("not base64!").unwrap_err();
+            Ed25519PrivateKey::from_base64("not base64!").unwrap_err();
+
+            // Valid Base64 but an empty payload (no flag byte).
+            SimpleKeypair::from_base64("").unwrap_err();
+
+            // Valid Base64 but an unknown scheme flag (0xff).
+            use base64ct::Encoding;
+            let payload = base64ct::Base64::decode_vec(UPSTREAM_ED25519_BASE64).unwrap();
+            let mut bad_flag_payload = payload.clone();
+            bad_flag_payload[0] = 0xff;
+            let bad_flag = base64ct::Base64::encode_string(&bad_flag_payload);
+            SimpleKeypair::from_base64(&bad_flag).unwrap_err();
+
+            // Valid Base64 and flag but truncated key bytes.
+            let truncated = base64ct::Base64::encode_string(&payload[..16]);
+            SimpleKeypair::from_base64(&truncated).unwrap_err();
         }
     }
 }

--- a/crates/sui-crypto/src/suipriv.rs
+++ b/crates/sui-crypto/src/suipriv.rs
@@ -1,48 +1,74 @@
-//! Encoding and decoding helpers for the Sui `suiprivkey` Bech32 format.
+//! Encoding and decoding helpers for the serialized Sui private key formats.
 //!
-//! The format mirrors the one produced by the Sui CLI and the `sui-types`
-//! crate: a 33-byte payload of `flag || private_key` encoded as a Bech32
-//! (BIP-173) string with the human-readable part `suiprivkey`. The leading
-//! flag byte is the `SignatureScheme` flag for the contained key (`0x00` for
-//! Ed25519, `0x01` for Secp256k1, `0x02` for Secp256r1).
+//! Both formats carry the same payload of `flag || private_key`, where the
+//! leading flag byte is the `SignatureScheme` flag for the contained key
+//! (`0x00` for Ed25519, `0x01` for Secp256k1, `0x02` for Secp256r1). The
+//! payload has two wire encodings, mirroring the Sui CLI and the `sui-types`
+//! crate:
 //!
-//! These helpers are kept `pub(crate)` on purpose. Callers reach the format
+//! - `bech32`: a Bech32 (BIP-173) string with the human-readable part
+//!   `suiprivkey`, produced by `sui keytool generate` and `sui keytool
+//!   export`.
+//! - `base64`: a plain Base64 string, the legacy encoding used for entries
+//!   of the Sui CLI's `sui.keystore` file and by older versions of `sui
+//!   keytool`.
+//!
+//! These helpers are kept `pub(crate)` on purpose. Callers reach the formats
 //! through strongly-typed wrappers like `Ed25519PrivateKey::from_suiprivkey`
-//! or `SimpleKeypair::from_suiprivkey` to avoid handing raw key bytes back as
-//! a `Vec<u8>` at the public boundary.
+//! or `SimpleKeypair::from_base64` to avoid handing raw key bytes back as a
+//! `Vec<u8>` at the public boundary.
 
-use bech32::Bech32;
-use bech32::Hrp;
-use bech32::primitives::decode::CheckedHrpstring;
 use sui_sdk_types::SignatureScheme;
 
 use crate::SignatureError;
 
-/// The human-readable part of the `suiprivkey` Bech32 encoding.
-const HRP: &str = "suiprivkey";
-
-fn hrp() -> Hrp {
-    // "suiprivkey" is a valid Bech32 HRP (lowercase ASCII, length 10).
-    Hrp::parse(HRP).expect("`suiprivkey` is a valid Bech32 HRP")
-}
-
-/// Encode a `flag || private_key` payload as a Bech32 `suiprivkey` string.
-pub(crate) fn encode(scheme: SignatureScheme, key: &[u8]) -> Result<String, SignatureError> {
+/// Join a scheme flag and key bytes into a `flag || private_key` payload.
+fn join_payload(scheme: SignatureScheme, key: &[u8]) -> Vec<u8> {
     let mut payload = Vec::with_capacity(1 + key.len());
     payload.push(scheme.to_u8());
     payload.extend_from_slice(key);
-    bech32::encode::<Bech32>(hrp(), &payload)
+    payload
+}
+
+/// Split a `flag || private_key` payload into its scheme flag and key bytes.
+///
+/// The returned key bytes are not validated against the scheme — the caller
+/// is responsible for verifying the length and constructing a scheme-specific
+/// key from them.
+fn split_payload(bytes: &[u8]) -> Result<(SignatureScheme, Vec<u8>), SignatureError> {
+    let (flag, key) = bytes
+        .split_first()
+        .ok_or_else(|| SignatureError::from_source("private key payload is empty"))?;
+    let scheme = SignatureScheme::from_byte(*flag).map_err(|e| {
+        SignatureError::from_source(format!("invalid private key scheme flag: {e}"))
+    })?;
+    Ok((scheme, key.to_vec()))
+}
+
+/// The human-readable part of the `suiprivkey` Bech32 encoding.
+#[cfg(feature = "bech32")]
+const HRP: &str = "suiprivkey";
+
+#[cfg(feature = "bech32")]
+fn hrp() -> bech32::Hrp {
+    // "suiprivkey" is a valid Bech32 HRP (lowercase ASCII, length 10).
+    bech32::Hrp::parse(HRP).expect("`suiprivkey` is a valid Bech32 HRP")
+}
+
+/// Encode a `flag || private_key` payload as a Bech32 `suiprivkey` string.
+#[cfg(feature = "bech32")]
+pub(crate) fn encode(scheme: SignatureScheme, key: &[u8]) -> Result<String, SignatureError> {
+    bech32::encode::<bech32::Bech32>(hrp(), &join_payload(scheme, key))
         .map_err(|e| SignatureError::from_source(format!("bech32 encode failed: {e}")))
 }
 
 /// Decode a Bech32 `suiprivkey` string into its scheme flag and key bytes.
 ///
 /// The BIP-173 checksum is validated strictly; Bech32m-checksummed strings are
-/// rejected. The returned key bytes are everything after the flag byte and
-/// are not validated against the scheme — the caller is responsible for
-/// verifying the length and constructing a scheme-specific key from them.
+/// rejected.
+#[cfg(feature = "bech32")]
 pub(crate) fn decode(s: &str) -> Result<(SignatureScheme, Vec<u8>), SignatureError> {
-    let parsed = CheckedHrpstring::new::<Bech32>(s)
+    let parsed = bech32::primitives::decode::CheckedHrpstring::new::<bech32::Bech32>(s)
         .map_err(|e| SignatureError::from_source(format!("invalid suiprivkey string: {e}")))?;
 
     if parsed.hrp() != hrp() {
@@ -52,10 +78,22 @@ pub(crate) fn decode(s: &str) -> Result<(SignatureScheme, Vec<u8>), SignatureErr
     }
 
     let bytes: Vec<u8> = parsed.byte_iter().collect();
-    let (flag, key) = bytes
-        .split_first()
-        .ok_or_else(|| SignatureError::from_source("suipriv payload is empty"))?;
-    let scheme = SignatureScheme::from_byte(*flag)
-        .map_err(|e| SignatureError::from_source(format!("invalid suipriv scheme flag: {e}")))?;
-    Ok((scheme, key.to_vec()))
+    split_payload(&bytes)
+}
+
+/// Encode a `flag || private_key` payload as a legacy Base64 keystore string.
+pub(crate) fn encode_base64(scheme: SignatureScheme, key: &[u8]) -> String {
+    use base64ct::Encoding;
+
+    base64ct::Base64::encode_string(&join_payload(scheme, key))
+}
+
+/// Decode a legacy Base64 keystore string into its scheme flag and key bytes.
+pub(crate) fn decode_base64(s: &str) -> Result<(SignatureScheme, Vec<u8>), SignatureError> {
+    use base64ct::Encoding;
+
+    let bytes = base64ct::Base64::decode_vec(s).map_err(|e| {
+        SignatureError::from_source(format!("invalid base64 private key string: {e}"))
+    })?;
+    split_payload(&bytes)
 }


### PR DESCRIPTION
The Sui CLI's sui.keystore file (and older versions of sui keytool) serialize private keys as Base64 of the same flag || private_key payload that the suiprivkey Bech32 format carries. Add from_base64/to_base64 to Ed25519PrivateKey, Secp256k1PrivateKey, Secp256r1PrivateKey, and SimpleKeypair, mirroring the from_suiprivkey/to_suiprivkey API.

The shared payload handling moves into suipriv.rs, and the per-type scheme-flag and length validation is factored into a private from_flagged_key_bytes helper used by both decoders. As a side effect Secp256r1PrivateKey::from_suiprivkey no longer panics on key bytes that do not form a valid secp256r1 scalar; it returns an error like the secp256k1 decoder already did.

No new cargo feature: base64ct is already an unconditional transitive dependency via sui-sdk-types, so the methods are available whenever the corresponding key scheme is enabled.

Also add SimpleVerifiyingKey::derive_address so a holder of a SimpleKeypair can compute the corresponding Sui address without matching on MultisigMemberPublicKey.